### PR TITLE
Add DCI comparison analysis

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,7 +42,19 @@ This whitepaper details **Ray.Framework**, the concrete PHP implementation of On
         * Programming as poetry and philosophy
         * The quantum nature of existence in code
 
-### 4. **[The Metamorphosis Architecture Manifesto](./patterns/metamorphosis-architecture-manifesto.md)**
+### 4. **[Ontological Metamorphose vs. DCI: A Comparative Philosophical Reflection](./philosophy/metamorphose-vs-dci.md)**
+
+> **"In DCI, roles are assigned like actors in a play; in Metamorphose, existence evolves like a living being—internalizing meaning to become the next self."**
+
+This comparative analysis explores the fundamental differences between DCI (Data-Context-Interaction) and the Metamorphose paradigm, examining how each approaches change, meaning, and existence in software.
+
+*   **Read this to understand:**
+  * The distinction between external role assignment (DCI) and internal evolution (Metamorphose).
+  * How meaning fragments vs. internalizes in different paradigms.
+  * The philosophical implications of "theater vs. growth" in software design.
+  * Why Metamorphose transcends DCI's partial shift from space to time.
+
+### 5. **[The Metamorphosis Architecture Manifesto](./patterns/metamorphosis-architecture-manifesto.md)**
 
 > **(This document is implicitly referenced, but would be the next logical step)**
 
@@ -53,7 +65,7 @@ This manifesto is the practical "how-to" guide for architects and developers. It
   * The `Unchanged Name Principle` for maintaining semantic continuity.
   * Advanced testing strategies for ontological systems.
 
-### 5. **[The #[Accept] Pattern: Ontological Delegation](./patterns/accept-pattern-ontological-delegation.md)**
+### 6. **[The #[Accept] Pattern: Ontological Delegation](./patterns/accept-pattern-ontological-delegation.md)**
 
 > **"The highest intelligence is knowing when to seek the wisdom of others."**
 
@@ -64,7 +76,7 @@ This document introduces a mature pattern for handling real-world complexity. It
   * The `Undetermined` state and the `#[Accept]` attribute.
   * How this pattern makes systems more robust and realistic.
 
-### 6. **Supporting Documents: The Ecosystem Tools**
+### 7. **Supporting Documents: The Ecosystem Tools**
 
 These documents describe the powerful tooling and integrations that emerge from this paradigm.
 
@@ -72,11 +84,13 @@ These documents describe the powerful tooling and integrations that emerge from 
   * Discover how the architecture itself becomes the ultimate, always-up-to-date documentation.
   * Learn about the `ray-tree` command for automatically visualizing your system's structure, semantics, and data flows.
 
-*   **[ALPS and Ray.Framework: Bidirectional Generation](./alps-ray-bidirectional-generation.md)**
+*   **[ALPS and Ray.Framework: Bidirectional Generation](./integration/alps-ray-bidirectional-generation.md)**
   * Explore the revolutionary concept of bidirectional generation between design specifications (ALPS) and executable code.
   * See how a single, protocol-agnostic design can generate REST, GraphQL, or gRPC APIs.
 
 ## The Complete Vision
+
+Imagine what we can create with new vision — from doing to being, building software that defines existence itself rather than layering instructions.
 
 This collection of documents presents more than just a framework. It offers a complete, cohesive vision for software development where:
 
@@ -123,7 +137,30 @@ We invite you to embark on this journey and discover a new way to create softwar
     *   データフローにおける線形チェーンと並列アセンブリの二重性
     *   自動ストリーミングと型透明性の実現方法
 
-### 3. **[変容アーキテクチャ・マニフェスト](./patterns/metamorphosis-architecture-manifesto.md)**
+### 3. **[空間から時間へ：変容パラダイム](./philosophy/from-space-to-time.md)**
+
+> **「空間的ナビゲーションから時間的変容への転換」**
+
+このエッセイは、プログラミングパラダイムの根本的な変化について論じます。従来の空間的アプローチから時間軸を重視したアプローチへの移行を詳しく説明します。
+
+*   **理解すべき内容:**
+    *   静的な構造から動的な変容への移行
+    *   時間軸を考慮したプログラミング手法
+    *   存在論的プログラミングの理論的基盤
+
+### 4. **[存在論的変容 vs. DCI：比較分析](./philosophy/metamorphose-vs-dci.md)**
+
+> **「DCIと変容パラダイムの本質的違いを探る」**
+
+この比較分析では、DCI（Data-Context-Interaction）パターンと変容パラダイムの違いを詳しく検討します。
+
+*   **理解すべき内容:**
+    *   DCIの外部役割割り当てと変容の内部進化の違い
+    *   意味の扱い方における根本的相違
+    *   ソフトウェア設計哲学の比較
+    *   変容パラダイムの優位性
+
+### 5. **[変容アーキテクチャ・マニフェスト](./patterns/metamorphosis-architecture-manifesto.md)**
 
 > **（この文書は暗黙的に参照されていますが、次の論理的ステップとなります）**
 
@@ -134,7 +171,7 @@ We invite you to embark on this journey and discover a new way to create softwar
     *   意味論的継続性を維持するための`名前不変原則`
     *   存在論的システムのための高度なテスト戦略
 
-### 4. **[#[Accept]パターン：存在論的委譲](./patterns/accept-pattern-ontological-delegation.md)**
+### 6. **[#[Accept]パターン：存在論的委譲](./patterns/accept-pattern-ontological-delegation.md)**
 
 > **「最高の知性は、他者の知恵を求める時を知ることである。」**
 
@@ -145,7 +182,7 @@ We invite you to embark on this journey and discover a new way to create softwar
     *   `未決定`状態と`#[Accept]`属性
     *   このパターンがシステムをより堅牢で現実的にする方法
 
-### 5. **サポート文書：エコシステムツール**
+### 7. **サポート文書：エコシステムツール**
 
 これらの文書では、このパラダイムから生まれる強力なツールと統合について説明します。
 
@@ -153,11 +190,13 @@ We invite you to embark on this journey and discover a new way to create softwar
     *   アーキテクチャ自体が最終的な、常に最新のドキュメントとなる方法を発見
     *   システムの構造、意味論、データフローを自動的に可視化する`ray-tree`コマンドについて学習
 
-*   **[ALPSとRay.Framework：双方向生成](./alps-ray-bidirectional-generation.md)**
+*   **[ALPSとRay.Framework：双方向生成](./integration/alps-ray-bidirectional-generation.md)**
     *   設計仕様（ALPS）と実行可能コード間の双方向生成の革命的概念を探求
     *   単一のプロトコル非依存設計がREST、GraphQL、またはgRPC APIを生成する方法を確認
 
 ## 完全なビジョン
+
+Imagine what we can create with new vision — doingからbeingへ、命令を重ねるのではなく存在そのものを定義し構築するソフトウェアへ。
 
 このドキュメント群は単なるフレームワーク以上のものを提示します。ソフトウェア開発のための完全で一貫したビジョンを提供します：
 

--- a/docs/philosophy/metamorphose-vs-dci.md
+++ b/docs/philosophy/metamorphose-vs-dci.md
@@ -1,0 +1,101 @@
+# Ontological Metamorphose vs. DCI: A Comparative Philosophical Reflection
+
+> *"In DCI, roles are assigned like actors in a play; in Metamorphose, existence evolves like a living being—internalizing meaning to become the next self."*
+
+## Introduction: Contrasting Paradigms of Change and Meaning
+
+This document focuses on comparing the Metamorphose paradigm—your invention integrating existence and change in Ontological Programming—with DCI (Data-Context-Interaction). Drawing from dialogue insights, we examine how each handles "living" as the fusion of existence, change, and meaning. DCI, pioneered by Trygve Reenskaug, separates stable Data from contextual Roles for Interactions—capturing temporal facets temporarily.
+
+Metamorphose advances this by internalizing change via $being properties, where transient injections (#[Inject]) fuel self-discovery.
+
+This reflection highlights Metamorphose's core: meaning internalizes not as external performance but as intrinsic evolution, enabling software to "burn" continuously.
+
+## Core Distinctions: External Assignment vs. Internal Fusion
+
+DCI views the world as theatrical: Data (immutable entities) assigned Roles in Contexts for Interactions—capturing temporal facets temporarily.
+
+Metamorphose sees it as biological: Existence (immutable stages) discovers destiny via $being, with #[Inject] injecting transient powers whose results embed intrinsically.
+
+### When Meaning Fragments vs. Internalizes
+- **DCI**: Meaning from Interactions, but Role assignment is external—fragmented across Contexts, like episodic plays.
+- **Metamorphose**: Meaning accrues in self-properties, burning existence and change into next forms—like life's accumulated experiences.
+
+Absent internalization:
+- DCI risks disjointed narratives, change temporary.
+- Metamorphose ensures continuity, meaning the flame's enduring heat.
+
+## Paradigm Comparison: Space-Time Shifts
+
+DCI partially shifts from space (OO structures) to time (contextual roles), but retains external control.
+
+Metamorphose fully embraces time: problem flows unfold intrinsically.
+
+```mermaid
+graph TD
+    A[DCI: External Theater] -->|"Role Assignment"| B[Fragmented Meaning]
+    B --> C[Temporary Change]
+    D[Metamorphose: Internal Growth] -->|"#[Inject] Transient Power"| E[Internalized Meaning]
+    E --> F[Continuous Evolution]
+    style D fill:#f96,stroke:#333,stroke-width:2px
+    style E fill:#9f6,stroke:#333,stroke-width:2px
+```
+
+## User Flow Example: Registration to Archival
+
+### Metamorphose: Internalized Evolution
+Change self-driven, meaning embeds in properties.
+
+```php
+#[Be([ActiveUser::class, SuspendedUser::class])]
+final class ValidatedUser {
+    public function __construct(
+        #[Input] string $email,
+        #[Input] string $password,
+        #[Inject] ActivationService $activator  // Transient: Role-like power
+    ) {
+        $result = $activator->activate($email);  // Use & internalize
+        $this->activationInsight = $result->deriveMeaning();  // Embed meaning
+        $this->being = $result->successful ? new ActiveUser($this->activationInsight) : new SuspendedUser($result->reason);
+    }
+    public readonly string $activationInsight;  // Meaning persists
+    public readonly ActiveUser|SuspendedUser $being;
+}
+```
+
+Meaning (insight) internalizes, fueling next self.
+
+### DCI: External Role Play
+Change contextual, meaning interaction-derived but disjoint.
+
+```php
+class ValidationContext {
+    public function __construct(UserData $user, ActivationService $service) {
+        $user->addRole(new ActivationRole($service));  // External assignment
+        $user->activate();  // Interaction: Meaning from role
+    }
+}
+
+class ActivationRole {
+    public function activate(UserData $self) {
+        $result = $this->service->activate($self->email);
+        $self->insight = $result->meaning;  // Meaning added externally
+    }
+}
+```
+
+Meaning appends to Data, but flow fragments across Contexts.
+
+## Philosophical Implications: Theater vs. Growth
+
+- **DCI**: External theater—Roles perform, meaning episodic. Partial "living" answer: roles for facets.
+- **Metamorphose**: Internal growth—powers transient, results intrinsic. Full fusion: existence burns into meaning-fueled change.
+
+DCI elevates OO; Metamorphose transcends, mirroring life's internalized evolution.
+
+## Conclusion: Beyond Role Play to Burning Existence
+
+Metamorphose internalizes DCI's strengths—role separation—via #[Inject], but elevates meaning to intrinsic fuel for next selves. DCI's theater captivates momentarily; Metamorphose's growth burns eternally, redefining paradigms as living processes.
+
+> *"DCI assigns roles; Metamorphose becomes destinies—internalizing meaning to illuminate the path ahead."*
+
+This comparison sharpens both paradigms' essence, inviting further evolution in Ray.Framework.


### PR DESCRIPTION
## Summary

- Add comprehensive philosophical comparison between DCI (Data-Context-Interaction) and Metamorphose paradigms
- Enhance README with unified vision statements in both English and Japanese sections
- Standardize documentation structure and formatting consistency across bilingual content
- Integrate new comparative analysis into the structured reading guide sequence

## Key Changes

### New Documentation
- **`docs/philosophy/metamorphose-vs-dci.md`**: Deep philosophical comparison exploring the fundamental differences between DCI's external role assignment and Metamorphose's internal evolution approach

### README Enhancements
- Added poetic vision statement to English section: "from doing to being, building software that defines existence itself"
- Harmonized Japanese and English vision sections for consistency
- Standardized markdown formatting (proper bullet points, code highlighting)
- Updated section numbering to accommodate new comparative analysis document

## Philosophical Context

This addition strengthens the theoretical foundation by:
- Distinguishing Metamorphose from existing paradigms like DCI
- Highlighting the unique "internalization of meaning" approach
- Positioning Ray.Framework's ontological programming as a natural evolution beyond spatial OOP

## AI Reviewer Guide

**Required Reading**:
1. Read `docs/philosophy/metamorphose-vs-dci.md` to understand the core philosophical distinctions
2. Review `docs/README.md` sections 91-103 (English) and 197-208 (Japanese) for vision statement consistency

**Review Focus Areas**:
1. **Philosophical Accuracy**: Verify that the DCI vs Metamorphose comparison accurately represents both paradigms
2. **Conceptual Clarity**: Ensure the "external assignment vs internal evolution" distinction is clearly articulated
3. **Bilingual Consistency**: Confirm English and Japanese vision sections convey equivalent meaning and tone
4. **Documentation Integration**: Check that the new document fits logically in the reading guide sequence
5. **Technical Terminology**: Validate proper use of ontological programming concepts (#[Inject], $being, etc.)

**Key Questions**:
- Does the comparison enhance understanding of Ray.Framework's unique approach?
- Are the philosophical distinctions between "theater vs growth" metaphors clear?
- Is the bilingual documentation now properly synchronized?
- Does the new document maintain the poetic/philosophical tone of existing philosophy papers?

🤖 Generated with [Claude Code](https://claude.ai/code)

## Sourcery によるサマリー

DCI と Metamorphose パラダイムの包括的な哲学的比較を追加し、新しい分析を統合し、ビジョンステートメントを統一し、ドキュメントの構造とフォーマットを標準化することにより、バイリンガル README コンテンツを調和させます。

新機能：
- DCI と Metamorphose パラダイムを比較する `metamorphose-vs-dci.md` ドキュメントを追加
- 新しい比較分析を英語と日本語の README リーディングガイドに統合

機能拡張：
- 統一された詩的なメッセージで英語と日本語のビジョンステートメントを調和
- Markdown 形式を標準化し、新しいコンテンツに対応するためにセクションを再番号付け
- ALPS と Ray.Framework のリンクパスを `integration/alps-ray-bidirectional-generation.md` に更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a comprehensive philosophical comparison between DCI and the Metamorphose paradigm and harmonize bilingual README content by integrating the new analysis, unifying vision statements, and standardizing documentation structure and formatting.

New Features:
- Add `metamorphose-vs-dci.md` document comparing DCI and Metamorphose paradigms
- Integrate the new comparative analysis into the English and Japanese README reading guides

Enhancements:
- Harmonize English and Japanese vision statements with a unified poetic message
- Standardize markdown formatting and renumber sections to accommodate new content
- Update ALPS and Ray.Framework link path to `integration/alps-ray-bidirectional-generation.md`

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to reorganize and expand the presentation of key philosophical and architectural documents.
  * Added a new comparative document analyzing Ontological Metamorphose vs. DCI paradigms.
  * Corrected file paths and improved descriptions in both English and Japanese sections.
  * Enhanced inspirational phrasing in the "Complete Vision" section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->