### PR TITLE
From Perfect Form to Whole New Being: An Ontological Shift in Metamorphosis

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Be Framework is a PHP framework that implements the Ontological Programming para
 
 Be Framework emerged from a simple yet profound question: What if we programmed by defining what can exist, rather than what should happen?
 
-Building upon the philosophical foundations of Ray.Di's dependency injection pattern, Be Framework treats all data transformations as metamorphosis—continuous becoming through constructor injection. Each object accepts its inevitable premises and transforms itself into a new, perfect form through the process of becoming.
+Building upon the philosophical foundations of Ray.Di's dependency injection pattern, Be Framework treats all data transformations as metamorphosis—continuous becoming through constructor injection. Each object accepts its inevitable premises and emerges as a whole new being through the process of becoming.
 
 In Be Framework, every transformation arises from the interaction of:
 


### PR DESCRIPTION
When I use the word "perfect", I recall that the thing has no room for change. I think "wholeness" is more suitable in this "becoming" context as the object is already being as a whole.

## Sourceryによる要約

ドキュメント:
- READMEで「perfect form」を「whole new being」に置き換え、完璧さよりも全体性を強調

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Replace “perfect form” with “whole new being” in the README to emphasize wholeness over perfection

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the description of object transformation in the Be Framework to clarify the metaphor used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->