### PR TITLE
Fix: Correct SemanticValidator namespace in FormalGreeting example

### DIFF
--- a/example/Being/FormalGreeting.php
+++ b/example/Being/FormalGreeting.php
@@ -27,7 +27,7 @@ final readonly class FormalGreeting
         #[Input] #[English] public string $name,         // Immanent
         #[Input] public FormalStyle $being    // Transcendent
     ) {
-        // Semantic validartion during metamorphosis
+        // Semantic validation during metamorphosis
         $validator = new SemanticValidator('Be\\Example\\Semantic');
         $errors = $validator->validate('name', $name);
         if ($errors->hasErrors()) {

--- a/example/Being/FormalGreeting.php
+++ b/example/Being/FormalGreeting.php
@@ -28,7 +28,7 @@ final readonly class FormalGreeting
         #[Input] public FormalStyle $being    // Transcendent
     ) {
         // Semantic validartion during metamorphosis
-        $validator = new SemanticValidator('Be\\Example\\Ontology');
+        $validator = new SemanticValidator('Be\\Example\\Semantic');
         $errors = $validator->validate('name', $name);
         if ($errors->hasErrors()) {
             throw new SemanticVariableException($errors);


### PR DESCRIPTION
## Summary
Fix namespace reference in `FormalGreeting.php` example.
- `Ontology` → `Semantic`

This resolves the notice when running `hello-world.php`.

---
Originally opened at https://github.com/chatii/be-framework/pull/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected which validation logic is applied to formal greeting inputs so validation is more accurate.
* **Documentation**
  * Fixed a typo in an inline comment related to validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->