### PR TITLE
Rewrite README: domain in the first person

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,83 @@
 # Be Framework
 
-> "Be, Don't Do" - A paradigm where objects represent states of being, not collections of behaviors.
+> A paradigm where the domain, seen in the first person, ceaselessly transforms through encounters with others — proving its existence in every becoming.
 
-**The Ontological Programming Framework for PHP**
+**"Be, Don't Do"**
 
-Be Framework implements Ontological Programming - focusing on *what things are* rather than *what they do*. Objects represent immutable states that transform through constructor-driven metamorphosis.
+## The Core Shift: Domain in the First Person
 
-## Key Features
+In conventional programming, the system operates on the domain from a god's-eye view: fetch, validate, save — all commands issued in the third person. Even "Tell, Don't Ask" still has a commander.
 
-* **New Paradigm** - Shift from "what to do" to "what to be"
-* **Semantic Variables** - Variable names carry meaning and constraints
-* **AI Native** - Define meaning and constraints, let AI optimize implementation
-* **No Invalid States** - Objects can't exist in broken states
-* **Temporal Existence** - Time and domain are inseparable; objects exist in time
-* **Natural Testing** - Each state is independently verifiable
+Be Framework places the viewpoint inside the domain itself. The domain is the subject. Everything that follows is derived from this single shift in perspective.
+
+### Self-Proving Existence
+
+An `Email` object doesn't get validated — it either exists or it doesn't. Existence itself is proof of correctness. Semantic variables embody this principle: they define a world where invalid values simply cannot be.
+
+### Transformation Through Encounter
+
+The domain transforms itself through encounters with others. What it already is (immanent) meets what the world provides (transcendent), and a new being emerges. A `PatientArrival` encounters a triage protocol and becomes an `EmergencyCase` — not because something processes it, but because it becomes.
+
+### Self-Determined Relations
+
+The domain determines its own relationships with others. Unlike controllers that can call any model without constraint, each being declares what it can become. The `#[Be]` attribute is this declaration — the domain's own voice saying what transformation is possible.
+
+### No Commander
+
+There is no orchestrator, no service class directing the flow. Input enters and flows through a landscape of beings like water finding its path. This is choreography — each dancer knows only their own part, yet the whole emerges in harmony.
+
+```php
+$becoming = new Becoming($injector);
+$final = $becoming(new OrderInput($items, $customer, $payment));
+```
+
+One line. No controller. The domain transforms itself.
+
+## What Does This Look Like?
+
+```php
+#[Be(Greeting::class)]
+final readonly class NameInput
+{
+    public function __construct(
+        public string $name  // Immanent: what I am
+    ) {}
+}
+
+final readonly class Greeting
+{
+    public string $message;
+
+    public function __construct(
+        #[Input] string $name,              // Immanent: carried forward
+        #[Inject] WorldGreeting $greeting   // Transcendent: what I encounter
+    ) {
+        $this->message = "{$greeting->text} {$name}";  // New immanent: what I become
+    }
+}
+```
+
+```php
+$becoming = new Becoming($injector);
+$greeting = $becoming(new NameInput('world'));
+
+echo $greeting->message; // hello world
+```
+
+`NameInput` declares that it can become a `Greeting`. When it encounters `WorldGreeting` from the outside world, it transforms. Each class is immutable — not because immutability is a goal, but because a being in a moment is that moment's being alone.
 
 ## Documentation
 
-* [Full Documentation](https://be-framework.github.io/)
+**[Full Documentation](https://be-framework.github.io/)**
 
-## Quick Learning
+## Demos
 
-* [Video](https://notebooklm.google.com/notebook/9295e6d1-4e4c-4e21-b666-f922b3a6dc3c?artifactId=9c29a99d-a2ca-4047-926e-104d55f6aeba) [日本語版](https://notebooklm.google.com/notebook/9295e6d1-4e4c-4e21-b666-f922b3a6dc3c?artifactId=59ed27f9-16da-4143-8144-f0afca6a39c0)
-* [Podcast](https://notebooklm.google.com/notebook/9295e6d1-4e4c-4e21-b666-f922b3a6dc3c?artifactId=3d724e12-8f96-414a-907d-16c72fc8930f) [日本語版](https://notebooklm.google.com/notebook/9295e6d1-4e4c-4e21-b666-f922b3a6dc3c?artifactId=f722825c-8c43-4de7-8610-50ed32a0194b)
+**[be-demos](https://github.com/be-framework/be-demos)** — Working examples of Be Framework in action
 
+## Philosophical Roots
 
-## Demo
+Across cultures and centuries, deep inquiry into the nature of things arrives at the same place: existence and time. If that is where all fundamental questions converge, the domain too might be described in those terms — that is the question this paradigm explores.
 
-Run the hello-world example to see Be Framework in action:
+## Status
 
-```bash
-php example/hello-world.php
-```
-
-This demonstrates:
-
-- Constructor-driven metamorphosis
-- Type-driven branching (formal vs casual styles)
-- Semantic validation with meaningful error messages
-- Automatic transformation through `#[Be]` attributes
-
+Be Framework is currently in the conceptual and early implementation phase.


### PR DESCRIPTION
## Summary

- READMEをフルスクラッチで再構成
- 「ドメインを一人称に据える」を中心に、全ての特性（自己証明、変容、自己決定、コレオグラフィー）がそこから導出される構造に
- 哲学的背景は証人としてではなく「存在と時間への問い」として簡潔に
- 防衛的なThe Journeyセクションを削除
- コード例を`final readonly class`に統一

## Test plan

- [ ] README.mdの表示確認
- [ ] コード例の構文確認
- [ ] リンク先の有効性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with new conceptual framing and philosophical foundation
  * Added PHP code examples demonstrating core framework patterns
  * Refreshed resource links to documentation and demos repository
  * Added project status note indicating early phase development

<!-- end of auto-generated comment: release notes by coderabbit.ai -->