### PR TITLE
Add cross-field semantic validation in automatic Becoming flow

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,4 +12,6 @@ parameters:
     - identifier: missingType.iterableValue
     # ReflectionMethod::invoke() throws exceptions from invoked methods,
     # but PHPStan cannot trace through reflection calls
-    - identifier: catch.neverThrown
+    -
+        identifier: catch.neverThrown
+        path: src/SemanticVariable/SemanticValidator.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,3 +10,6 @@ parameters:
     - identifier: return.phpDocType
     - identifier: property.phpDocType
     - identifier: missingType.iterableValue
+    # ReflectionMethod::invoke() throws exceptions from invoked methods,
+    # but PHPStan cannot trace through reflection calls
+    - identifier: catch.neverThrown

--- a/src/SemanticVariable/SemanticValidator.php
+++ b/src/SemanticVariable/SemanticValidator.php
@@ -165,48 +165,76 @@ final class SemanticValidator implements SemanticValidatorInterface
             }
 
             $checkedClasses[] = $className;
+            $exceptions = [...$exceptions, ...$this->invokeCrossFieldMethods($semanticClass, $allArgs)];
+        }
 
-            $reflection = new ReflectionClass($semanticClass);
-            foreach ($reflection->getMethods() as $validateMethod) {
-                if (empty($validateMethod->getAttributes(Validate::class))) {
-                    continue;
-                }
+        return $exceptions;
+    }
 
-                $nonInjectParams = array_values(array_filter(
-                    $validateMethod->getParameters(),
-                    static fn (ReflectionParameter $p) => empty($p->getAttributes(Inject::class)),
-                ));
+    /**
+     * Invoke multi-parameter #[Validate] methods whose parameter names match available args
+     *
+     * @param ConstructorArguments $allArgs All constructor argument values
+     *
+     * @return list<DomainException>
+     */
+    private function invokeCrossFieldMethods(object $semanticClass, array $allArgs): array
+    {
+        $exceptions = [];
+        $reflection = new ReflectionClass($semanticClass);
 
-                if (count($nonInjectParams) < 2) {
-                    continue;
-                }
+        foreach ($reflection->getMethods() as $validateMethod) {
+            if (empty($validateMethod->getAttributes(Validate::class))) {
+                continue;
+            }
 
-                // Name-based matching: all parameter names must exist in $allArgs
-                $methodArgs = [];
-                $allParamsAvailable = true;
-                foreach ($nonInjectParams as $param) {
-                    if (! array_key_exists($param->getName(), $allArgs)) {
-                        $allParamsAvailable = false;
-                        break;
-                    }
+            $methodArgs = $this->matchArgsByName($validateMethod, $allArgs);
+            if ($methodArgs === null) {
+                continue;
+            }
 
-                    /** @psalm-suppress MixedAssignment */
-                    $methodArgs[] = $allArgs[$param->getName()];
-                }
-
-                if (! $allParamsAvailable) {
-                    continue;
-                }
-
-                try {
-                    $validateMethod->invoke($semanticClass, ...$methodArgs);
-                } catch (DomainException $exception) {
-                    $exceptions[] = $exception;
-                }
+            try {
+                $validateMethod->invoke($semanticClass, ...$methodArgs);
+            } catch (DomainException $exception) {
+                $exceptions[] = $exception;
             }
         }
 
         return $exceptions;
+    }
+
+    /**
+     * Match method parameters to available args by name
+     *
+     * Returns ordered argument values if all non-Inject parameters with 2+ params
+     * have matching names in $allArgs, or null if not matched.
+     *
+     * @param ConstructorArguments $allArgs All constructor argument values
+     *
+     * @return ValidationArguments|null
+     */
+    private function matchArgsByName(ReflectionMethod $method, array $allArgs): array|null
+    {
+        $nonInjectParams = array_values(array_filter(
+            $method->getParameters(),
+            static fn (ReflectionParameter $p) => empty($p->getAttributes(Inject::class)),
+        ));
+
+        if (count($nonInjectParams) < 2) {
+            return null;
+        }
+
+        $methodArgs = [];
+        foreach ($nonInjectParams as $param) {
+            if (! array_key_exists($param->getName(), $allArgs)) {
+                return null;
+            }
+
+            /** @psalm-suppress MixedAssignment */
+            $methodArgs[] = $allArgs[$param->getName()];
+        }
+
+        return $methodArgs;
     }
 
     /**

--- a/src/SemanticVariable/SemanticValidator.php
+++ b/src/SemanticVariable/SemanticValidator.php
@@ -110,6 +110,7 @@ final class SemanticValidator implements SemanticValidatorInterface
     {
         $allErrors = [];
 
+        // First pass: single-field validation
         foreach ($method->getParameters() as $parameter) {
             // Skip #[Inject] parameters
             if ($this->hasInjectAttribute($parameter)) {
@@ -125,7 +126,87 @@ final class SemanticValidator implements SemanticValidatorInterface
             }
         }
 
+        // Second pass: cross-field validation for multi-parameter #[Validate] methods
+        $crossFieldErrors = $this->validateCrossFieldArgs($method, $args);
+        $allErrors = [...$allErrors, ...$crossFieldErrors];
+
         return empty($allErrors) ? new NullErrors() : new Errors($allErrors);
+    }
+
+    /**
+     * Validate cross-field constraints using multi-parameter #[Validate] methods
+     *
+     * For each semantic class resolved from constructor parameters, finds #[Validate]
+     * methods with 2+ non-#[Inject] parameters whose names ALL exist in $allArgs.
+     *
+     * @param ReflectionMethod     $method  Constructor with parameter definitions
+     * @param ConstructorArguments $allArgs All constructor argument values
+     *
+     * @return list<DomainException>
+     */
+    private function validateCrossFieldArgs(ReflectionMethod $method, array $allArgs): array
+    {
+        $exceptions = [];
+        $checkedClasses = [];
+
+        foreach ($method->getParameters() as $parameter) {
+            if ($this->hasInjectAttribute($parameter)) {
+                continue;
+            }
+
+            $semanticClass = $this->resolveSemanticClass($parameter->getName());
+            if ($semanticClass === null) {
+                continue;
+            }
+
+            $className = $semanticClass::class;
+            if (in_array($className, $checkedClasses, true)) {
+                continue;
+            }
+
+            $checkedClasses[] = $className;
+
+            $reflection = new ReflectionClass($semanticClass);
+            foreach ($reflection->getMethods() as $validateMethod) {
+                if (empty($validateMethod->getAttributes(Validate::class))) {
+                    continue;
+                }
+
+                $nonInjectParams = array_values(array_filter(
+                    $validateMethod->getParameters(),
+                    static fn (ReflectionParameter $p) => empty($p->getAttributes(Inject::class)),
+                ));
+
+                if (count($nonInjectParams) < 2) {
+                    continue;
+                }
+
+                // Name-based matching: all parameter names must exist in $allArgs
+                $methodArgs = [];
+                $allParamsAvailable = true;
+                foreach ($nonInjectParams as $param) {
+                    if (! array_key_exists($param->getName(), $allArgs)) {
+                        $allParamsAvailable = false;
+                        break;
+                    }
+
+                    /** @psalm-suppress MixedAssignment */
+                    $methodArgs[] = $allArgs[$param->getName()];
+                }
+
+                if (! $allParamsAvailable) {
+                    continue;
+                }
+
+                try {
+                    $validateMethod->invoke($semanticClass, ...$methodArgs);
+                } catch (DomainException $exception) {
+                    $exceptions[] = $exception;
+                }
+            }
+        }
+
+        return $exceptions;
     }
 
     /**

--- a/tests/SemanticVariable/SemanticValidatorTest.php
+++ b/tests/SemanticVariable/SemanticValidatorTest.php
@@ -7,7 +7,10 @@ namespace Be\Framework\SemanticVariable;
 use Be\Framework\Exception\SemanticVariableException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use ReflectionMethod;
 use TypeError;
+
+use function assert;
 
 final class SemanticValidatorTest extends TestCase
 {
@@ -216,18 +219,12 @@ final class SemanticValidatorTest extends TestCase
     public function testCrossFieldValidationMatchingEmails(): void
     {
         $testClass = new class ('', '') {
-            public function __construct(
-                string $email,
-                string $confirmation,
-            ) {
+            public function __construct(string $email, string $confirmation)
+            {
             }
         };
 
-        $reflection = new ReflectionClass($testClass);
-        $constructor = $reflection->getConstructor();
-        $this->assertNotNull($constructor);
-
-        $errors = $this->validator->validateArgs($constructor, [
+        $errors = $this->validateArgsOf($testClass, [
             'email' => 'john@example.com',
             'confirmation' => 'john@example.com',
         ]);
@@ -238,18 +235,12 @@ final class SemanticValidatorTest extends TestCase
     public function testCrossFieldValidationMismatchingEmails(): void
     {
         $testClass = new class ('', '') {
-            public function __construct(
-                string $email,
-                string $confirmation,
-            ) {
+            public function __construct(string $email, string $confirmation)
+            {
             }
         };
 
-        $reflection = new ReflectionClass($testClass);
-        $constructor = $reflection->getConstructor();
-        $this->assertNotNull($constructor);
-
-        $errors = $this->validator->validateArgs($constructor, [
+        $errors = $this->validateArgsOf($testClass, [
             'email' => 'john@example.com',
             'confirmation' => 'jane@example.com',
         ]);
@@ -260,23 +251,27 @@ final class SemanticValidatorTest extends TestCase
     public function testCrossFieldValidationSkippedWhenParamNameMissing(): void
     {
         $testClass = new class ('', '') {
-            public function __construct(
-                string $email,
-                string $other,
-            ) {
+            public function __construct(string $email, string $other)
+            {
             }
         };
 
-        $reflection = new ReflectionClass($testClass);
-        $constructor = $reflection->getConstructor();
-        $this->assertNotNull($constructor);
-
-        $errors = $this->validator->validateArgs($constructor, [
+        $errors = $this->validateArgsOf($testClass, [
             'email' => 'john@example.com',
             'other' => 'some-value',
         ]);
 
         // validateEmailConfirmation needs $confirmation, not $other — should be skipped
         $this->assertFalse($errors->hasErrors());
+    }
+
+    /** @param array<string, mixed> $args */
+    private function validateArgsOf(object $testClass, array $args): Errors
+    {
+        $reflection = new ReflectionClass($testClass);
+        $constructor = $reflection->getConstructor();
+        assert($constructor instanceof ReflectionMethod);
+
+        return $this->validator->validateArgs($constructor, $args);
     }
 }

--- a/tests/SemanticVariable/SemanticValidatorTest.php
+++ b/tests/SemanticVariable/SemanticValidatorTest.php
@@ -212,4 +212,71 @@ final class SemanticValidatorTest extends TestCase
         $this->expectException(TypeError::class);
         $this->validator->validateArgs($method, ['email' => null]);
     }
+
+    public function testCrossFieldValidationMatchingEmails(): void
+    {
+        $testClass = new class ('', '') {
+            public function __construct(
+                string $email,
+                string $confirmation,
+            ) {
+            }
+        };
+
+        $reflection = new ReflectionClass($testClass);
+        $constructor = $reflection->getConstructor();
+        $this->assertNotNull($constructor);
+
+        $errors = $this->validator->validateArgs($constructor, [
+            'email' => 'john@example.com',
+            'confirmation' => 'john@example.com',
+        ]);
+
+        $this->assertInstanceOf(NullErrors::class, $errors);
+    }
+
+    public function testCrossFieldValidationMismatchingEmails(): void
+    {
+        $testClass = new class ('', '') {
+            public function __construct(
+                string $email,
+                string $confirmation,
+            ) {
+            }
+        };
+
+        $reflection = new ReflectionClass($testClass);
+        $constructor = $reflection->getConstructor();
+        $this->assertNotNull($constructor);
+
+        $errors = $this->validator->validateArgs($constructor, [
+            'email' => 'john@example.com',
+            'confirmation' => 'jane@example.com',
+        ]);
+
+        $this->assertTrue($errors->hasErrors());
+    }
+
+    public function testCrossFieldValidationSkippedWhenParamNameMissing(): void
+    {
+        $testClass = new class ('', '') {
+            public function __construct(
+                string $email,
+                string $other,
+            ) {
+            }
+        };
+
+        $reflection = new ReflectionClass($testClass);
+        $constructor = $reflection->getConstructor();
+        $this->assertNotNull($constructor);
+
+        $errors = $this->validator->validateArgs($constructor, [
+            'email' => 'john@example.com',
+            'other' => 'some-value',
+        ]);
+
+        // validateEmailConfirmation needs $confirmation, not $other — should be skipped
+        $this->assertFalse($errors->hasErrors());
+    }
 }


### PR DESCRIPTION
## Summary

- `validateArgs()` がコンストラクタパラメータを1つずつ処理していたため、マルチパラメータ `#[Validate]` メソッド（例: `validateEmailConfirmation(string $email, string $confirmation)`）が自動Becomingフロー中にスキップされていた問題を修正
- `validateCrossFieldArgs()` を追加し、名前ベースマッチングでクロスフィールド検証を自動適用
- クロスフィールド検証のテスト3件を追加

## Test plan

- [x] `testCrossFieldValidationMatchingEmails` — 一致するメール確認が通過
- [x] `testCrossFieldValidationMismatchingEmails` — 不一致でエラー検出
- [x] `testCrossFieldValidationSkippedWhenParamNameMissing` — パラメータ名不一致時はスキップ
- [x] 既存テスト全227件通過
- [x] `composer cs-fix` — スタイル問題なし
- [x] `composer sa` — PHPStan通過（既存Psalm警告のみ）

Fixes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Semantic validation now supports cross-parameter validation, enabling rules that evaluate relationships between multiple constructor parameters.

* **Tests**
  * Added tests covering cross-parameter validation: matching, mismatching, and the case where a required parameter name is absent (validation skipped).

* **Chores**
  * Updated static analysis configuration to handle exceptions from reflection-style invocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->