### PR TITLE
Add Been carrier and LDD loop verification

### DIFF
--- a/src/Module/BeModule.php
+++ b/src/Module/BeModule.php
@@ -8,10 +8,14 @@ use Be\Framework\Becoming;
 use Be\Framework\BecomingArguments;
 use Be\Framework\BecomingArgumentsInterface;
 use Be\Framework\BecomingInterface;
+use Be\Framework\SemanticLog\Been;
+use Be\Framework\SemanticLog\BeenProvider;
 use Be\Framework\SemanticLog\Logger;
 use Be\Framework\SemanticLog\LoggerInterface;
 use Be\Framework\SemanticVariable\SemanticValidator;
 use Be\Framework\SemanticVariable\SemanticValidatorInterface;
+use Koriym\SemanticLogger\SemanticLogger;
+use Koriym\SemanticLogger\SemanticLoggerInterface;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
 
@@ -26,7 +30,9 @@ final class BeModule extends AbstractModule
     {
         $this->bind(BecomingArgumentsInterface::class)->to(BecomingArguments::class);
         $this->bind(BecomingInterface::class)->to(Becoming::class);
+        $this->bind(SemanticLoggerInterface::class)->to(SemanticLogger::class)->in(Scope::SINGLETON);
         $this->bind(LoggerInterface::class)->to(Logger::class)->in(Scope::SINGLETON);
+        $this->bind(Been::class)->toProvider(BeenProvider::class);
         $this->bind(SemanticValidatorInterface::class)->to(SemanticValidator::class);
         $this->bind('')->annotatedWith('semantic_namespace')->toInstance($this->namespace);
     }

--- a/src/SemanticLog/Been.php
+++ b/src/SemanticLog/Been.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\SemanticLog;
+
+use Koriym\SemanticLogger\AbstractContext;
+use Koriym\SemanticLogger\SemanticLoggerInterface;
+
+/**
+ * Immutable carrier of a Final object's `$been` — ordered, typed evidence of
+ * what made it what it is.
+ *
+ * `Been` holds a list of `AbstractContext` events. Each call to `with()`
+ * appends a new event and returns a new `Been`; the original is untouched.
+ * Simultaneously, `with()` writes the event to the live
+ * `SemanticLoggerInterface` stream via `event()`, so the in-memory `$been`
+ * and the produced semantic log are the same thing viewed from two sides.
+ *
+ * The logger reference is held intentionally. This is not a violation of
+ * immutability — the event list is immutable, and the logger is external
+ * state. Do not "clean this up" by removing the logger call: deferring the
+ * event stream to after the constructor returns would lose spatial/temporal
+ * ordering and would drop events emitted before a constructor throw.
+ *
+ * Exception safety: `with()` writes to the stream **before** returning the
+ * new `Been`. If a later step throws, events already emitted remain on the
+ * stream — they reflect what actually happened, not what succeeded. This is
+ * correct logging semantics; do not expect transactional rollback.
+ */
+final class Been
+{
+    /** @param list<AbstractContext> $events */
+    public function __construct(
+        private readonly SemanticLoggerInterface $logger,
+        public readonly array $events = [],
+    ) {
+    }
+
+    public function with(AbstractContext $context): self
+    {
+        $this->logger->event($context);
+
+        return new self($this->logger, [...$this->events, $context]);
+    }
+}

--- a/src/SemanticLog/BeenProvider.php
+++ b/src/SemanticLog/BeenProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\SemanticLog;
+
+use Koriym\SemanticLogger\SemanticLoggerInterface;
+use Override;
+use Ray\Di\ProviderInterface;
+
+/**
+ * Provides a fresh empty `Been` accumulator to each `#[Inject] Been $been`.
+ *
+ * Scope is per-injection, not singleton — a new `Been` per metamorphosis
+ * step. For the single-step toy example this is all that is needed.
+ *
+ * Limitation: this provider does not thread `Been` across a multi-step
+ * metamorphosis chain. In a chain `A -> B -> C`, step B's injected `$been`
+ * does not contain step A's events. If/when multi-step accumulation is
+ * needed, the recommended route is `#[Input] Been $been` threading, which
+ * reuses `BecomingArguments`' existing name-matched `#[Input]` resolution
+ * and requires no engine changes — the first step simply constructs an
+ * empty `Been` and assigns it to a `public readonly Been $been` property,
+ * and every downstream step receives it via `#[Input]`.
+ *
+ * @implements ProviderInterface<Been>
+ */
+final class BeenProvider implements ProviderInterface
+{
+    public function __construct(
+        private readonly SemanticLoggerInterface $logger,
+    ) {
+    }
+
+    #[Override]
+    public function get(): Been
+    {
+        return new Been($this->logger);
+    }
+}

--- a/src/SemanticLog/Logger.php
+++ b/src/SemanticLog/Logger.php
@@ -20,6 +20,7 @@ use Ray\Di\Di\Inject;
 use ReflectionClass;
 use Throwable;
 
+use function array_filter;
 use function array_key_exists;
 use function array_keys;
 use function array_map;
@@ -213,8 +214,14 @@ final class Logger implements LoggerInterface
         // @todo Privacy/Security: Consider extracting shape-only metadata instead of actual values
         //       For production use, should emit property names + types only, not raw values
         //       e.g., ['email' => 'string', 'validated' => 'bool'] instead of actual data
-        // For now, get_object_vars() covers all realistic Be Framework objects
-        return get_object_vars($result);
+        // For now, get_object_vars() covers all realistic Be Framework objects.
+        //
+        // Exclude any `Been` property: it carries this very log and would
+        // embed the event stream recursively inside the close context.
+        return array_filter(
+            get_object_vars($result),
+            static fn (mixed $value): bool => ! ($value instanceof Been),
+        );
     }
 
     private function determineDestination(object $result): SingleDestination|MultipleDestination|FinalDestination

--- a/tests/FakeApp/Ldd/RegisterUser/Context/EmailFormatAssertedContext.php
+++ b/tests/FakeApp/Ldd/RegisterUser/Context/EmailFormatAssertedContext.php
@@ -13,7 +13,6 @@ final class EmailFormatAssertedContext extends AbstractContext
 
     public function __construct(
         public readonly string $email,
-        public readonly string $pattern,
     ) {
     }
 }

--- a/tests/FakeApp/Ldd/RegisterUser/Context/EmailFormatAssertedContext.php
+++ b/tests/FakeApp/Ldd/RegisterUser/Context/EmailFormatAssertedContext.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyApp\Ldd\RegisterUser\Context;
+
+use Koriym\SemanticLogger\AbstractContext;
+
+final class EmailFormatAssertedContext extends AbstractContext
+{
+    public const string TYPE = 'email_format_asserted';
+    public const string SCHEMA_URL = 'https://myvendor.example.com/schemas/email-format-asserted.json';
+
+    public function __construct(
+        public readonly string $email,
+        public readonly string $pattern,
+    ) {
+    }
+}

--- a/tests/FakeApp/Ldd/RegisterUser/Context/UserInsertedContext.php
+++ b/tests/FakeApp/Ldd/RegisterUser/Context/UserInsertedContext.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyApp\Ldd\RegisterUser\Context;
+
+use Koriym\SemanticLogger\AbstractContext;
+
+final class UserInsertedContext extends AbstractContext
+{
+    public const string TYPE = 'user_inserted';
+    public const string SCHEMA_URL = 'https://myvendor.example.com/schemas/user-inserted.json';
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly string $email,
+    ) {
+    }
+}

--- a/tests/FakeApp/Ldd/RegisterUser/EmailVerifier.php
+++ b/tests/FakeApp/Ldd/RegisterUser/EmailVerifier.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyApp\Ldd\RegisterUser;
+
+use function preg_match;
+
+/**
+ * Test double for an email format verifier. The real app would inject a
+ * domain service here; this one is enough to prove the LDD loop closes.
+ */
+final class EmailVerifier
+{
+    public function check(string $email): bool
+    {
+        return preg_match('/^[^@]+@[^@]+$/', $email) === 1;
+    }
+}

--- a/tests/FakeApp/Ldd/RegisterUser/EmailVerifier.php
+++ b/tests/FakeApp/Ldd/RegisterUser/EmailVerifier.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace MyVendor\MyApp\Ldd\RegisterUser;
 
-use function preg_match;
+use function filter_var;
+
+use const FILTER_VALIDATE_EMAIL;
 
 /**
  * Test double for an email format verifier. The real app would inject a
@@ -14,6 +16,6 @@ final class EmailVerifier
 {
     public function check(string $email): bool
     {
-        return preg_match('/^[^@]+@[^@]+$/', $email) === 1;
+        return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
     }
 }

--- a/tests/FakeApp/Ldd/RegisterUser/RegisteredUser.php
+++ b/tests/FakeApp/Ldd/RegisterUser/RegisteredUser.php
@@ -34,7 +34,6 @@ final class RegisteredUser
         $this->been = $been
             ->with(new EmailFormatAssertedContext(
                 email: $value,
-                pattern: '/^[^@]+@[^@]+$/',
             ))
             ->with(new UserInsertedContext(
                 userId: $this->userId,

--- a/tests/FakeApp/Ldd/RegisterUser/RegisteredUser.php
+++ b/tests/FakeApp/Ldd/RegisterUser/RegisteredUser.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyApp\Ldd\RegisterUser;
+
+use Be\Framework\Exception\UnbecomingException;
+use Be\Framework\SemanticLog\Been;
+use MyVendor\MyApp\Ldd\RegisterUser\Context\EmailFormatAssertedContext;
+use MyVendor\MyApp\Ldd\RegisterUser\Context\UserInsertedContext;
+use Ray\Di\Di\Inject;
+use Ray\InputQuery\Attribute\Input;
+
+final class RegisteredUser
+{
+    public readonly int $userId;
+    public readonly Been $been;
+
+    public function __construct(
+        #[Input]
+        public readonly string $value,
+        #[Inject]
+        EmailVerifier $verifier,
+        #[Inject]
+        UserRepository $users,
+        #[Inject]
+        Been $been,
+    ) {
+        if (! $verifier->check($value)) {
+            throw new UnbecomingException('email format failed');
+        }
+
+        $this->userId = $users->insert(['email' => $value]);
+        $this->been = $been
+            ->with(new EmailFormatAssertedContext(
+                email: $value,
+                pattern: '/^[^@]+@[^@]+$/',
+            ))
+            ->with(new UserInsertedContext(
+                userId: $this->userId,
+                email: $value,
+            ));
+    }
+}

--- a/tests/FakeApp/Ldd/RegisterUser/UnverifiedEmail.php
+++ b/tests/FakeApp/Ldd/RegisterUser/UnverifiedEmail.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyApp\Ldd\RegisterUser;
+
+use Be\Framework\Attribute\Be;
+
+#[Be(RegisteredUser::class)]
+final class UnverifiedEmail
+{
+    public function __construct(
+        public readonly string $value,
+    ) {
+    }
+}

--- a/tests/FakeApp/Ldd/RegisterUser/UserRepository.php
+++ b/tests/FakeApp/Ldd/RegisterUser/UserRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyApp\Ldd\RegisterUser;
+
+/**
+ * Test double for a user repository that returns a deterministic id on
+ * insert. The LDD reference spec (`been.json`) fixes the expected id to 42,
+ * and this repo honours that — keeps the test data stable across runs.
+ */
+final class UserRepository
+{
+    /** @param array{email: string} $row */
+    public function insert(array $row): int
+    {
+        return 42;
+    }
+}

--- a/tests/Integration/Ldd/RegisterUser/README.md
+++ b/tests/Integration/Ldd/RegisterUser/README.md
@@ -1,0 +1,44 @@
+# LDD Reference Example — Register User
+
+This directory holds the reference artifact for Log-Driven Development (LDD) in
+Be Framework: a hand-authored `$been` semantic log that **specifies** a
+metamorphosis. The JSON is not a trace captured from a run — it is a spec
+written first, from which the PHP classes are generated.
+
+## What this example says
+
+One metamorphosis step:
+
+```
+UnverifiedEmail  --#[Be(RegisteredUser::class)]-->  RegisteredUser
+```
+
+Along the way, two pieces of evidence are recorded as semantic events:
+
+1. `email_format_asserted` — the email was checked against a pattern.
+2. `user_inserted` — a row was created in the user store and received id `42`.
+
+The final object `RegisteredUser` carries these events on `public readonly Been
+$been` — proof of what made this object what it is.
+
+## Files
+
+- [`been.json`](been.json) — the authored specification, in SemanticLogger format.
+- Generated classes live under [`tests/FakeApp/Ldd/RegisterUser/`](../../../FakeApp/Ldd/RegisterUser/):
+  - `UnverifiedEmail.php` — source class with `#[Be(RegisteredUser::class)]`
+  - `RegisteredUser.php` — destination class whose constructor does the work
+  - `EmailVerifier.php`, `UserRepository.php` — fake services used via `#[Inject]`
+  - `Context/EmailFormatAssertedContext.php`, `Context/UserInsertedContext.php` — the two event contexts
+- [`tests/Integration/LddLoopTest.php`](../../LddLoopTest.php) — runs the generated code
+  and asserts the produced log is semantically equivalent to `been.json`.
+
+## The LDD loop this example closes
+
+1. A human (or an AI) authors `been.json` describing what ought to be.
+2. A skill (`.claude/skills/ldd-from-log.md`) reads the JSON and writes PHP.
+3. The PHP runs through `Becoming` and emits its own semantic log.
+4. The emitted log matches `been.json` (structurally; ids and timestamps ignored).
+
+When the loop closes, `been.json` is simultaneously the specification, the
+example, and the test. There is nothing for an external unit test to verify
+that the `$been` does not already carry.

--- a/tests/Integration/Ldd/RegisterUser/README.md
+++ b/tests/Integration/Ldd/RegisterUser/README.md
@@ -9,13 +9,13 @@ written first, from which the PHP classes are generated.
 
 One metamorphosis step:
 
-```
+```text
 UnverifiedEmail  --#[Be(RegisteredUser::class)]-->  RegisteredUser
 ```
 
 Along the way, two pieces of evidence are recorded as semantic events:
 
-1. `email_format_asserted` — the email was checked against a pattern.
+1. `email_format_asserted` — the email format was validated.
 2. `user_inserted` — a row was created in the user store and received id `42`.
 
 The final object `RegisteredUser` carries these events on `public readonly Been

--- a/tests/Integration/Ldd/RegisterUser/been.json
+++ b/tests/Integration/Ldd/RegisterUser/been.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "https://koriym.github.io/Koriym.SemanticLogger/schemas/combined.json",
+    "open": {
+        "id": "metamorphosis_open_1",
+        "type": "metamorphosis_open",
+        "schemaUrl": "https://be-framework.org/docs/schemas/metamorphosis-open.json",
+        "context": {
+            "fromClass": "MyVendor\\MyApp\\Ldd\\RegisterUser\\UnverifiedEmail",
+            "beAttribute": "#[Be(MyVendor\\MyApp\\Ldd\\RegisterUser\\RegisteredUser::class)]",
+            "immanentSources": {
+                "value": "MyVendor\\MyApp\\Ldd\\RegisterUser\\UnverifiedEmail::value"
+            },
+            "transcendentSources": {
+                "verifier": "MyVendor\\MyApp\\Ldd\\RegisterUser\\EmailVerifier",
+                "users": "MyVendor\\MyApp\\Ldd\\RegisterUser\\UserRepository",
+                "been": "Be\\Framework\\SemanticLog\\Been"
+            }
+        }
+    },
+    "events": [
+        {
+            "id": "email_format_asserted_1",
+            "type": "email_format_asserted",
+            "schemaUrl": "https://myvendor.example.com/schemas/email-format-asserted.json",
+            "context": {
+                "email": "alice@example.com",
+                "pattern": "/^[^@]+@[^@]+$/"
+            },
+            "openId": "metamorphosis_open_1"
+        },
+        {
+            "id": "user_inserted_1",
+            "type": "user_inserted",
+            "schemaUrl": "https://myvendor.example.com/schemas/user-inserted.json",
+            "context": {
+                "userId": 42,
+                "email": "alice@example.com"
+            },
+            "openId": "metamorphosis_open_1"
+        }
+    ],
+    "close": {
+        "id": "metamorphosis_close_1",
+        "type": "metamorphosis_close",
+        "schemaUrl": "https://be-framework.org/docs/schemas/metamorphosis-close.json",
+        "context": {
+            "properties": {
+                "userId": 42,
+                "value": "alice@example.com"
+            },
+            "be": {
+                "finalClass": "MyVendor\\MyApp\\Ldd\\RegisterUser\\RegisteredUser"
+            }
+        },
+        "openId": "metamorphosis_open_1"
+    }
+}

--- a/tests/Integration/Ldd/RegisterUser/been.json
+++ b/tests/Integration/Ldd/RegisterUser/been.json
@@ -23,8 +23,7 @@
             "type": "email_format_asserted",
             "schemaUrl": "https://myvendor.example.com/schemas/email-format-asserted.json",
             "context": {
-                "email": "alice@example.com",
-                "pattern": "/^[^@]+@[^@]+$/"
+                "email": "alice@example.com"
             },
             "openId": "metamorphosis_open_1"
         },

--- a/tests/Integration/LddLoopTest.php
+++ b/tests/Integration/LddLoopTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Tests\Integration;
+
+use Be\Framework\BecomingInterface;
+use Be\Framework\Module\BeModule;
+use Be\Framework\SemanticVariable\NullValidator;
+use Be\Framework\SemanticVariable\SemanticValidatorInterface;
+use Koriym\SemanticLogger\SemanticLoggerInterface;
+use MyVendor\MyApp\Ldd\RegisterUser\RegisteredUser;
+use MyVendor\MyApp\Ldd\RegisterUser\UnverifiedEmail;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\AbstractModule;
+use Ray\Di\Injector;
+
+use function assert;
+use function file_get_contents;
+use function is_array;
+use function json_decode;
+use function json_encode;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * End-to-end verification of the Log-Driven Development loop.
+ *
+ * Steps:
+ *   1. Load the hand-authored `$been` spec (`tests/Integration/Ldd/RegisterUser/been.json`).
+ *   2. Run the generated classes (`UnverifiedEmail` -> `RegisteredUser`)
+ *      through the framework's `Becoming` engine under full DI.
+ *   3. Flush the `SemanticLoggerInterface` singleton and normalise the result.
+ *   4. Assert the produced log equals the authored spec.
+ *
+ * If this test passes, the LDD loop closes: the JSON is simultaneously the
+ * specification, the example, and the test.
+ */
+final class LddLoopTest extends TestCase
+{
+    public function testRegisterUserLoopClosesOnAuthoredSpec(): void
+    {
+        $injector = new Injector(new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->install(new BeModule());
+                $this->bind(SemanticValidatorInterface::class)->to(NullValidator::class);
+            }
+        });
+        $becoming = $injector->getInstance(BecomingInterface::class);
+        $semanticLogger = $injector->getInstance(SemanticLoggerInterface::class);
+        assert($becoming instanceof BecomingInterface);
+        assert($semanticLogger instanceof SemanticLoggerInterface);
+
+        $result = $becoming(new UnverifiedEmail('alice@example.com'));
+        $this->assertInstanceOf(RegisteredUser::class, $result);
+
+        $produced = $this->normalise($semanticLogger->flush()->toArray());
+
+        $authoredJson = file_get_contents(__DIR__ . '/Ldd/RegisterUser/been.json');
+        $this->assertNotFalse($authoredJson);
+        /** @var array<string, mixed> $authored */
+        $authored = json_decode($authoredJson, true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame($authored, $produced);
+    }
+
+    /**
+     * Round-trip through json_encode/decode to flatten nested value objects
+     * (`FinalDestination`, etc.) into plain arrays for structural comparison.
+     *
+     * @param  array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    private function normalise(array $data): array
+    {
+        $encoded = json_encode($data, JSON_THROW_ON_ERROR);
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
+        assert(is_array($decoded));
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## Summary

- **`Been`**: Immutable event carrier. `with(AbstractContext)` appends an event and simultaneously writes to the live `SemanticLoggerInterface` stream
- **`BeenProvider`**: Ray.Di Provider that returns a fresh empty `Been` per injection
- **`BeModule`**: Add `SemanticLoggerInterface` singleton binding and `Been` provider binding
- **`Logger::extractProperties()`**: Filter out `Been` properties to prevent self-reference in close context
- **`LddLoopTest`**: End-to-end assertion that hand-authored `been.json` exactly equals the produced semantic log — closing the LDD loop

## Design

A final object's `$been` (proof-of-existence) and the SemanticLogger's produced JSON are the same thing viewed from two sides. `Been::with()` builds both simultaneously, so authored JSON = produced log holds by construction.

## Test plan

- [x] `LddLoopTest::testRegisterUserLoopClosesOnAuthoredSpec` — `assertSame` between authored `been.json` and produced log (3 assertions)
- [x] All 225 existing tests pass (no regressions)
- [x] `composer cs` — all 11 changed files clean
- [x] `composer sa` — no new errors (only pre-existing PHPStan/Psalm issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced semantic logging framework with improved event tracking and context management capabilities.

* **Tests**
  * Added comprehensive integration tests demonstrating semantic logging workflows with practical examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->