### PR TITLE
Simplify metamorphosis open/close schemas to match emitted context

### DIFF
--- a/docs/schemas/metamorphosis-close.json
+++ b/docs/schemas/metamorphosis-close.json
@@ -2,61 +2,78 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://be-framework.org/schemas/metamorphosis-close.json",
   "title": "Metamorphosis Close Context",
-  "description": "Schema for transformation completion - object properties AFTER instantiation",
+  "description": "Result captured at the end of a metamorphosis: the constructed being's public properties and its next destination.",
   "type": "object",
-  "required": ["fromClass", "toClass", "beAttribute", "resultProperties", "success"],
+  "required": ["properties", "be"],
   "properties": {
-    "fromClass": {
-      "type": "string",
-      "description": "Class that was transformed from",
-      "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\\\[A-Za-z_][A-Za-z0-9_]*)*$"
-    },
-    "toClass": {
-      "type": "string",
-      "description": "Class that was transformed to",
-      "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\\\[A-Za-z_][A-Za-z0-9_]*)*$"
-    },
-    "beAttribute": {
-      "type": "string",
-      "description": "The #[Be] attribute that triggered transformation",
-      "examples": ["#[Be(ValidatedUser::class)]", "#[Be([Success::class, Failure::class])]"]
-    },
-    "resultProperties": {
+    "properties": {
       "type": "object",
-      "description": "Object properties after construction",
+      "description": "Public readonly properties of the constructed being (excluding the Been log carrier).",
       "additionalProperties": true
     },
-    "success": {
-      "type": "boolean",
-      "description": "Whether the transformation succeeded"
-    },
-    "error": {
-      "type": ["string", "null"],
-      "description": "Error message if transformation failed"
-    },
-    "duration": {
-      "type": "number",
-      "description": "Time taken for this transformation in seconds",
-      "minimum": 0
-    },
-    "memoryUsage": {
-      "type": "integer",
-      "description": "Memory used during transformation in bytes",
-      "minimum": 0
+    "be": {
+      "description": "Next metamorphosis destination — a single class, a branch of candidate classes, a terminal class, or a not-found record.",
+      "oneOf": [
+        {
+          "title": "SingleDestination",
+          "type": "object",
+          "required": ["nextClass"],
+          "properties": {
+            "nextClass": {
+              "type": "string",
+              "description": "Fully-qualified class name of the next being."
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "title": "MultipleDestination",
+          "type": "object",
+          "required": ["possibleClasses"],
+          "properties": {
+            "possibleClasses": {
+              "type": "array",
+              "description": "Candidate class names considered for the next being.",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "title": "FinalDestination",
+          "type": "object",
+          "required": ["finalClass"],
+          "properties": {
+            "finalClass": {
+              "type": "string",
+              "description": "Fully-qualified class name of the terminal being."
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "title": "DestinationNotFound",
+          "type": "object",
+          "required": ["error"],
+          "properties": {
+            "error": {
+              "type": "string",
+              "description": "Reason the destination could not be resolved."
+            },
+            "attemptedClasses": {
+              "type": "array",
+              "description": "Class names that were tried and rejected.",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
     }
   },
-  "links": [
-    {
-      "anchor": "#/properties/resultProperties",
-      "rel": "describedby",
-      "href": "https://be-framework.org/docs/being-classes",
-      "title": "Being Classes Documentation"
-    },
-    {
-      "anchor": "#/properties/error",
-      "rel": "related",
-      "href": "https://be-framework.org/docs/error-handling",
-      "title": "Error Handling in Be Framework"
-    }
-  ]
+  "additionalProperties": false
 }

--- a/docs/schemas/metamorphosis-open.json
+++ b/docs/schemas/metamorphosis-open.json
@@ -2,45 +2,36 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://be-framework.org/schemas/metamorphosis-open.json",
   "title": "Metamorphosis Open Context",
-  "description": "Schema for transformation start - constructor arguments BEFORE instantiation",
+  "description": "Arguments captured at the start of a metamorphosis — just before the next being is instantiated.",
   "type": "object",
   "required": ["fromClass", "beAttribute"],
   "properties": {
     "fromClass": {
       "type": "string",
-      "description": "Class being transformed from",
-      "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\\\[A-Za-z_][A-Za-z0-9_]*)*$"
+      "description": "Fully-qualified class name of the being being transformed from."
     },
     "beAttribute": {
       "type": "string",
-      "description": "The #[Be] attribute triggering this transformation",
-      "examples": ["#[Be(ValidatedUser::class)]", "#[Be([Success::class, Failure::class])]"]
+      "description": "Stringified #[Be(...)] attribute declaring the next destination.",
+      "examples": [
+        "#[Be(ValidatedUser::class)]",
+        "#[Be([Success::class, Failure::class])]"
+      ]
     },
     "immanentSources": {
       "type": "object",
-      "description": "#[Input] parameter values from previous object",
-      "additionalProperties": true
+      "description": "Map of #[Input] parameter names to their origin path on the previous being.",
+      "additionalProperties": {
+        "type": "string"
+      }
     },
     "transcendentSources": {
       "type": "object",
-      "description": "#[Inject] interface/service names from DI container",
+      "description": "Map of #[Inject] parameter names to the interface / service identifier resolved from the DI container.",
       "additionalProperties": {
         "type": "string"
       }
     }
   },
-  "links": [
-    {
-      "anchor": "#/properties/beAttribute",
-      "rel": "describedby",
-      "href": "https://be-framework.org/docs/be-attribute",
-      "title": "Be Attribute Documentation"
-    },
-    {
-      "anchor": "#/properties/immanentSources",
-      "rel": "describedby",
-      "href": "https://be-framework.org/docs/immanent-transcendent",
-      "title": "Immanent and Transcendent Factors"
-    }
-  ]
+  "additionalProperties": false
 }

--- a/src/SemanticLog/Context/MetamorphosisCloseContext.php
+++ b/src/SemanticLog/Context/MetamorphosisCloseContext.php
@@ -33,17 +33,13 @@ final class MetamorphosisCloseContext extends AbstractContext implements JsonSer
     ) {
     }
 
-    /** @return ObjectProperties */
+    /** @return array{properties: object, be: SingleDestination|MultipleDestination|FinalDestination|DestinationNotFound} */
     #[Override]
     public function jsonSerialize(): array
     {
-        // For now, create a simplified structure that matches schema
         return [
-            'fromClass' => 'Unknown',
-            'toClass' => 'Unknown',
-            'beAttribute' => 'Unknown',
-            'resultProperties' => empty($this->properties) ? new stdClass() : (object) $this->properties,
-            'success' => true, // Simplified for now
+            'properties' => empty($this->properties) ? new stdClass() : (object) $this->properties,
+            'be' => $this->be,
         ];
     }
 }

--- a/tests/SemanticLog/JsonSchemaValidationTest.php
+++ b/tests/SemanticLog/JsonSchemaValidationTest.php
@@ -179,20 +179,4 @@ final class JsonSchemaValidationTest extends TestCase
             'Should report missing required field',
         );
     }
-
-    public function testInvalidClassNamePatternFailsValidation(): void
-    {
-        // Create context with invalid class name pattern
-        $invalidData = (object) [
-            'fromClass' => '123InvalidClassName', // Class names can't start with numbers
-            'beAttribute' => '#[Be(ValidClass::class)]',
-        ];
-
-        $this->validator->validate($invalidData, $this->openSchema, Constraint::CHECK_MODE_NORMAL);
-
-        $this->assertFalse(
-            $this->validator->isValid(),
-            'Invalid class name pattern should fail validation',
-        );
-    }
 }


### PR DESCRIPTION
## Summary

The JSON schemas for \`metamorphosis_open\` / \`metamorphosis_close\` were out of sync with the context objects actually emitted by \`MetamorphosisOpenContext\` / \`MetamorphosisCloseContext\`. This PR simplifies both schemas to describe only the fields that exist.

- **open**: drops unused \`pattern\` regex on class names and \`links\`; adds \`additionalProperties: false\`
- **close**: rewritten to \`{properties, be: oneOf[4 destinations]}\` matching the Single/Multiple/Final/DestinationNotFound shape
- \`MetamorphosisCloseContext::jsonSerialize()\` emits \`properties\` as an object (\`stdClass\`) when empty so schema validation stays consistent
- Drops \`testInvalidClassNamePatternFailsValidation\` (was coupled to the removed regex)

Companion change to \`koriym/Koriym.SemanticLogger\` adds a renderer that consumes the simplified context shape and reproduces the framework vocabulary on output.

## Test plan

- [x] \`composer cs-fix\`
- [x] \`composer sa\`
- [x] \`vendor/bin/phpunit --no-coverage\`
- [x] \`docs/_site/schemas/*\` kept in sync with \`docs/schemas/*\`