### PR TITLE
Bump koriym/semantic-logger to ^0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.3",
         "ray/di": "^2.18",
         "ray/input-query": "^v1.0",
-        "koriym/semantic-logger": "^0.3"
+        "koriym/semantic-logger": "^0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^12.2",


### PR DESCRIPTION
The \`becoming_*\` context reshape merged in #64 targets \`koriym/semantic-logger\` 0.4's APIs (generic \`SignalExtractor\`, \`NodeFormatterInterface\`, and \`SemanticLogger\`'s \`JsonSerializable\`-aware \`contextToArray\`). With 0.4.0 released on Packagist, the \`^0.3\` constraint here prevents consumers from picking up the matching version.

Changes: one line in composer.json — \`"koriym/semantic-logger": "^0.3"\` → \`"^0.4"\`.

Tests: 231 pass locally against the updated dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated semantic-logger dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->