### PR TITLE
Wrap chain span and reshape step contexts as Being/Final/Error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^8.3",
         "ray/di": "^2.18",
         "ray/input-query": "^v1.0",
-        "koriym/semantic-logger": "^0.4"
+        "koriym/semantic-logger": "^0.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^12.2",

--- a/docs/schemas/becoming-close.json
+++ b/docs/schemas/becoming-close.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://be-framework.org/schemas/becoming-close.json",
+  "title": "Becoming Close Context",
+  "description": "Close context for the outer chain span. On success, carries the final being's FQCN; on failure, carries the exception that ended the chain.",
+  "type": "object",
+  "properties": {
+    "final": {
+      "type": "string",
+      "description": "Fully-qualified class name of the terminal being reached when the chain succeeded."
+    },
+    "error": {
+      "type": "string",
+      "description": "Fully-qualified class name of the thrown exception when the chain ended in failure."
+    },
+    "message": {
+      "type": "string",
+      "description": "Exception message when the chain ended in failure."
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/becoming-close.json
+++ b/docs/schemas/becoming-close.json
@@ -4,6 +4,21 @@
   "title": "Becoming Close Context",
   "description": "Close context for the outer chain span. On success, carries the final being's FQCN; on failure, carries the exception that ended the chain.",
   "type": "object",
+  "oneOf": [
+    {
+      "required": ["final"],
+      "not": {
+        "anyOf": [
+          { "required": ["error"] },
+          { "required": ["message"] }
+        ]
+      }
+    },
+    {
+      "required": ["error", "message"],
+      "not": { "required": ["final"] }
+    }
+  ],
   "properties": {
     "final": {
       "type": "string",

--- a/docs/schemas/becoming-open.json
+++ b/docs/schemas/becoming-open.json
@@ -2,35 +2,13 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://be-framework.org/schemas/becoming-open.json",
   "title": "Becoming Open Context",
-  "description": "Captured when a metamorphosis starts — what we are trying to become and which inputs/injects feed it.",
+  "description": "Outer span that wraps an entire metamorphosis chain. Each being_open/being_*_close inside appears as a sibling child under this single root.",
   "type": "object",
-  "required": ["from", "be", "input", "inject"],
+  "required": ["input"],
   "properties": {
-    "from": {
-      "type": "string",
-      "description": "Fully-qualified class name of the being being transformed from."
-    },
-    "be": {
-      "type": "string",
-      "description": "Target class for the next metamorphosis. Single FQCN, or pipe-joined FQCNs when the attribute declares multiple candidates.",
-      "examples": [
-        "App\\Being\\ValidatedUser",
-        "App\\Being\\Success|App\\Being\\Failure"
-      ]
-    },
     "input": {
-      "type": "object",
-      "description": "Map of #[Input] parameter names to their origin path on the previous being.",
-      "additionalProperties": {
-        "type": "string"
-      }
-    },
-    "inject": {
-      "type": "object",
-      "description": "Map of #[Inject] parameter names to the interface / service identifier resolved from the DI container.",
-      "additionalProperties": {
-        "type": "string"
-      }
+      "type": "string",
+      "description": "Fully-qualified class name of the initial input being that starts the chain."
     }
   },
   "additionalProperties": false

--- a/docs/schemas/being-close.json
+++ b/docs/schemas/being-close.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://be-framework.org/schemas/becoming-being.json",
-  "title": "Becoming Being Context",
+  "$id": "https://be-framework.org/schemas/being-close.json",
+  "title": "Being Close Context",
   "description": "Close context for a metamorphosis that produced a new being which will itself continue transforming.",
   "type": "object",
   "required": ["being", "prop"],

--- a/docs/schemas/being-error-close.json
+++ b/docs/schemas/being-error-close.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://be-framework.org/schemas/becoming-error.json",
-  "title": "Becoming Error Context",
+  "$id": "https://be-framework.org/schemas/being-error-close.json",
+  "title": "Being Error Close Context",
   "description": "Close context for a metamorphosis that failed with a thrown exception.",
   "type": "object",
   "required": ["error", "message"],

--- a/docs/schemas/being-final-close.json
+++ b/docs/schemas/being-final-close.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://be-framework.org/schemas/becoming-final.json",
-  "title": "Becoming Final Context",
+  "$id": "https://be-framework.org/schemas/being-final-close.json",
+  "title": "Being Final Close Context",
   "description": "Close context for a metamorphosis that reached a terminal being — no further #[Be] attribute.",
   "type": "object",
   "required": ["final", "prop"],

--- a/docs/schemas/being-final-close.json
+++ b/docs/schemas/being-final-close.json
@@ -14,6 +14,13 @@
       "type": "object",
       "description": "Public readonly properties of the terminal being.",
       "additionalProperties": true
+    },
+    "been": {
+      "type": "array",
+      "description": "Ordered events the terminal being curated into its own `$been` carrier via `with()`. Each entry is a semantic-logger context (object). Omitted when the terminal being has no `$been` or curated nothing.",
+      "items": {
+        "type": "object"
+      }
     }
   },
   "additionalProperties": false

--- a/docs/schemas/being-final-open.json
+++ b/docs/schemas/being-final-open.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://be-framework.org/schemas/being-final-open.json",
+  "title": "Being Final Open Context",
+  "description": "Captured when a terminal being starts — the target has no #[Be] attribute, so this step produces the final being of the chain.",
+  "type": "object",
+  "required": ["from", "be", "input", "inject"],
+  "properties": {
+    "from": {
+      "type": "string",
+      "description": "Fully-qualified class name of the being being transformed from."
+    },
+    "be": {
+      "type": "string",
+      "description": "Fully-qualified class name of the target terminal being.",
+      "examples": [
+        "App\\Being\\RegisteredUser"
+      ]
+    },
+    "input": {
+      "type": "object",
+      "description": "Map of #[Input] parameter names to their origin path on the previous being.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "inject": {
+      "type": "object",
+      "description": "Map of #[Inject] parameter names to the interface / service identifier resolved from the DI container.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/schemas/being-final-open.json
+++ b/docs/schemas/being-final-open.json
@@ -4,15 +4,15 @@
   "title": "Being Final Open Context",
   "description": "Captured when a terminal being starts — the target has no #[Be] attribute, so this step produces the final being of the chain.",
   "type": "object",
-  "required": ["from", "be", "input", "inject"],
+  "required": ["from", "final", "input", "inject"],
   "properties": {
     "from": {
       "type": "string",
       "description": "Fully-qualified class name of the being being transformed from."
     },
-    "be": {
+    "final": {
       "type": "string",
-      "description": "Fully-qualified class name of the target terminal being.",
+      "description": "Fully-qualified class name of the target terminal being — the landing point of this step.",
       "examples": [
         "App\\Being\\RegisteredUser"
       ]

--- a/docs/schemas/being-open.json
+++ b/docs/schemas/being-open.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://be-framework.org/schemas/being-open.json",
+  "title": "Being Open Context",
+  "description": "Captured when an intermediate being starts — the target carries a #[Be] attribute, so the metamorphosis will continue after this step.",
+  "type": "object",
+  "required": ["from", "be", "input", "inject"],
+  "properties": {
+    "from": {
+      "type": "string",
+      "description": "Fully-qualified class name of the being being transformed from."
+    },
+    "be": {
+      "type": "string",
+      "description": "Fully-qualified class name of the target being for the next metamorphosis.",
+      "examples": [
+        "App\\Being\\ValidatedUser"
+      ]
+    },
+    "input": {
+      "type": "object",
+      "description": "Map of #[Input] parameter names to their origin path on the previous being.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "inject": {
+      "type": "object",
+      "description": "Map of #[Inject] parameter names to the interface / service identifier resolved from the DI container.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/semantic-log-architecture.md
+++ b/docs/semantic-log-architecture.md
@@ -41,10 +41,10 @@ UserInput → ValidatedUser → RegisteredUser → ActiveUser
 **Purpose**: Captures constructor arguments BEFORE instantiation
 - **When**: Called immediately before each constructor call
 - **What it captures**:
-  - `from`:   Class being transformed from
-  - `be`:     Target class FQCN
-  - `input`:  `#[Input]` parameter sources from previous object
-  - `inject`: `#[Inject]` service types from DI container
+  - `from`:        Class being transformed from
+  - `be` / `final`: Target class FQCN — `be` on `BeingOpenContext` (intent to continue), `final` on `BeingFinalOpenContext` (landing on the terminal being)
+  - `input`:       `#[Input]` parameter sources from previous object
+  - `inject`:      `#[Inject]` service types from DI container
 
 ## BeingCloseContext / BeingFinalCloseContext / BeingErrorCloseContext (Close)
 **Purpose**: Captures transformation results AFTER instantiation
@@ -52,6 +52,7 @@ UserInput → ValidatedUser → RegisteredUser → ActiveUser
 - **Success close captures**:
   - `prop`:   All public properties of the created object
   - `being` / `final`: FQCN of the resulting being (new-becoming or terminal)
+  - `been` (BeingFinalCloseContext only): the events the terminal being curated into its own `$been` carrier via `with()`. Emitted only when the final being carries a `Been` that accumulated events — the logger reference itself is not included.
 - **Error close captures**:
   - `error`:   Exception class name
   - `message`: Exception message
@@ -102,7 +103,7 @@ $logger->close(new BeingCloseContext(
 // 3. OPEN: About to transform RegisteredUser (terminal target — no #[Be])
 $openId3 = $logger->open(new BeingFinalOpenContext(
     from:   'RegisteredUser',
-    be:     'ActiveUser',
+    final:  'ActiveUser',
     input:  ['userId' => 'RegisteredUser::userId', 'email' => 'RegisteredUser::email'],
     inject: ['emailService' => 'EmailService'],
 ));

--- a/docs/semantic-log-architecture.md
+++ b/docs/semantic-log-architecture.md
@@ -6,7 +6,7 @@ The Be Framework uses **koriym/semantic-logger** to provide transparent logging 
 
 ## Open-Close Pattern for Individual Transformations
 
-```
+```text
 BeingOpenContext (OPEN)              - "About to transform UserInput using SemanticValidator"
     ↓ [Constructor execution happens here]
 BeingCloseContext / BeingFinalCloseContext / BeingErrorCloseContext (CLOSE)
@@ -26,7 +26,7 @@ The close context comes in three forms, picked by the result state:
 
 Each transformation gets its own open/close pair:
 
-```
+```text
 UserInput → ValidatedUser → RegisteredUser → ActiveUser
 
 1. OPEN: UserInput transformation intent        (BeingOpenContext)

--- a/docs/semantic-log-architecture.md
+++ b/docs/semantic-log-architecture.md
@@ -7,65 +7,60 @@ The Be Framework uses **koriym/semantic-logger** to provide transparent logging 
 ## Open-Close Pattern for Individual Transformations
 
 ```
-MetamorphosisOpenContext (OPEN) - "About to transform UserInput using SemanticValidator"
+BeingOpenContext (OPEN)              - "About to transform UserInput using SemanticValidator"
     ↓ [Constructor execution happens here]
-MetamorphosisCloseContext (CLOSE) - "UserInput became ValidatedUser with properties {...}"
+BeingCloseContext / BeingFinalCloseContext / BeingErrorCloseContext (CLOSE)
+                                     - "UserInput became ValidatedUser with properties {...}"
 ```
+
+The open context comes in two forms, picked by whether the target class declares a `#[Be]` attribute:
+
+- `BeingOpenContext` — target carries `#[Be]`, the metamorphosis will continue.
+- `BeingFinalOpenContext` — target has no `#[Be]`, this step produces the terminal being.
+
+The close context comes in three forms, picked by the result state:
+
+- `BeingCloseContext` — result has a `#[Be]` attribute; pipeline will continue.
+- `BeingFinalCloseContext` — result has no `#[Be]`; chain ends here.
+- `BeingErrorCloseContext` — constructor threw; open-close could not complete.
 
 Each transformation gets its own open/close pair:
 
 ```
 UserInput → ValidatedUser → RegisteredUser → ActiveUser
 
-1. OPEN: UserInput transformation intent
-   CLOSE: ValidatedUser result + next destination
-2. OPEN: ValidatedUser transformation intent  
-   CLOSE: RegisteredUser result + next destination
-3. OPEN: RegisteredUser transformation intent
-   CLOSE: ActiveUser result + final destination
+1. OPEN: UserInput transformation intent        (BeingOpenContext)
+   CLOSE: ValidatedUser result                  (BeingCloseContext)
+2. OPEN: ValidatedUser transformation intent    (BeingOpenContext)
+   CLOSE: RegisteredUser result                 (BeingCloseContext)
+3. OPEN: RegisteredUser transformation intent   (BeingFinalOpenContext)
+   CLOSE: ActiveUser result                     (BeingFinalCloseContext)
 ```
 
-## MetamorphosisOpenContext (Open)
+## BeingOpenContext / BeingFinalOpenContext (Open)
 **Purpose**: Captures constructor arguments BEFORE instantiation
 - **When**: Called immediately before each constructor call
 - **What it captures**:
-  - `fromClass`: Class being transformed from
-  - `beAttribute`: The `#[Be]` attribute string (e.g., `#[Be(ValidatedUser::class)]`)
-  - `immanentSources`: `#[Input]` parameter sources from previous object
-  - `transcendentSources`: `#[Inject]` service types from DI container
+  - `from`:   Class being transformed from
+  - `be`:     Target class FQCN
+  - `input`:  `#[Input]` parameter sources from previous object
+  - `inject`: `#[Inject]` service types from DI container
 
-## MetamorphosisCloseContext (Close)  
+## BeingCloseContext / BeingFinalCloseContext / BeingErrorCloseContext (Close)
 **Purpose**: Captures transformation results AFTER instantiation
-- **When**: Called immediately after successful constructor completion
-- **What it captures**:
-  - `properties`: All public properties of the created object
-  - `be`: Next destination information (SingleDestination, MultipleDestination, FinalDestination, or DestinationNotFound)
+- **When**: Called immediately after successful constructor completion, or after a thrown exception
+- **Success close captures**:
+  - `prop`:   All public properties of the created object
+  - `being` / `final`: FQCN of the resulting being (new-becoming or terminal)
+- **Error close captures**:
+  - `error`:   Exception class name
+  - `message`: Exception message
 
-## Destination Types
+## Chain wrapper
 
-### SingleDestination
-Object has a single next transformation: `#[Be(SomeClass::class)]`
-```php
-new SingleDestination(nextClass: 'RegisteredUser');
-```
-
-### MultipleDestination  
-Object has branching possibilities: `#[Be([Success::class, Failure::class])]`
-```php
-new MultipleDestination(possibleClasses: ['Success', 'Failure']);
-```
-
-### FinalDestination
-Object has no `#[Be]` attribute - transformation chain ends here
-```php
-new FinalDestination(finalClass: 'ActiveUser');
-```
-
-### DestinationNotFound
-Transformation failed or type matching failed
-```php
-new DestinationNotFound(error: 'No matching constructor found', attemptedClasses: ['UserA', 'UserB']);
-```
+Each full metamorphosis chain is wrapped in a `BecomingOpenContext` / `BecomingCloseContext`
+pair. These are emitted once per top-level `Becoming::__invoke` call, giving the log a
+single root with every step-level open/close as sibling children.
 
 ## Real Implementation Example
 
@@ -73,51 +68,51 @@ new DestinationNotFound(error: 'No matching constructor found', attemptedClasses
 // User Registration Flow: UserInput → ValidatedUser → RegisteredUser → ActiveUser
 
 // 1. OPEN: About to transform UserInput
-$openId1 = $logger->open(new MetamorphosisOpenContext(
-    fromClass: 'UserInput',
-    beAttribute: '#[Be(ValidatedUser::class)]',
-    immanentSources: ['email' => 'UserInput::email', 'age' => 'UserInput::age'],
-    transcendentSources: ['validator' => 'SemanticValidator']
+$openId1 = $logger->open(new BeingOpenContext(
+    from:   'UserInput',
+    be:     'ValidatedUser',
+    input:  ['email' => 'UserInput::email', 'age' => 'UserInput::age'],
+    inject: ['validator' => 'SemanticValidator'],
 ));
 
 // [ValidatedUser constructor executes]
 
 // 1. CLOSE: UserInput became ValidatedUser
-$logger->close(new MetamorphosisCloseContext(
-    properties: ['email' => 'user@example.com', 'age' => 25, 'isValid' => true],
-    be: new SingleDestination('RegisteredUser')
+$logger->close(new BeingCloseContext(
+    being: 'ValidatedUser',
+    prop:  ['email' => 'user@example.com', 'age' => 25, 'isValid' => true],
 ), $openId1);
 
 // 2. OPEN: About to transform ValidatedUser
-$openId2 = $logger->open(new MetamorphosisOpenContext(
-    fromClass: 'ValidatedUser', 
-    beAttribute: '#[Be(RegisteredUser::class)]',
-    immanentSources: ['email' => 'ValidatedUser::email'],
-    transcendentSources: ['repository' => 'UserRepository']
+$openId2 = $logger->open(new BeingOpenContext(
+    from:   'ValidatedUser',
+    be:     'RegisteredUser',
+    input:  ['email' => 'ValidatedUser::email'],
+    inject: ['repository' => 'UserRepository'],
 ));
 
 // [RegisteredUser constructor executes]
 
 // 2. CLOSE: ValidatedUser became RegisteredUser
-$logger->close(new MetamorphosisCloseContext(
-    properties: ['userId' => '123', 'email' => 'user@example.com', 'createdAt' => '2024-01-01'],
-    be: new SingleDestination('ActiveUser')
+$logger->close(new BeingCloseContext(
+    being: 'RegisteredUser',
+    prop:  ['userId' => '123', 'email' => 'user@example.com', 'createdAt' => '2024-01-01'],
 ), $openId2);
 
-// 3. OPEN: About to transform RegisteredUser  
-$openId3 = $logger->open(new MetamorphosisOpenContext(
-    fromClass: 'RegisteredUser',
-    beAttribute: '#[Be(ActiveUser::class)]',
-    immanentSources: ['userId' => 'RegisteredUser::userId', 'email' => 'RegisteredUser::email'],
-    transcendentSources: ['emailService' => 'EmailService']
+// 3. OPEN: About to transform RegisteredUser (terminal target — no #[Be])
+$openId3 = $logger->open(new BeingFinalOpenContext(
+    from:   'RegisteredUser',
+    be:     'ActiveUser',
+    input:  ['userId' => 'RegisteredUser::userId', 'email' => 'RegisteredUser::email'],
+    inject: ['emailService' => 'EmailService'],
 ));
 
 // [ActiveUser constructor executes]
 
-// 3. CLOSE: RegisteredUser became ActiveUser (final destination)
-$logger->close(new MetamorphosisCloseContext(
-    properties: ['userId' => '123', 'email' => 'user@example.com', 'isActive' => true],
-    be: new FinalDestination('ActiveUser')  // No more transformations
+// 3. CLOSE: RegisteredUser became ActiveUser (final being)
+$logger->close(new BeingFinalCloseContext(
+    final: 'ActiveUser',
+    prop:  ['userId' => '123', 'email' => 'user@example.com', 'isActive' => true],
 ), $openId3);
 ```
 
@@ -126,32 +121,33 @@ $logger->close(new MetamorphosisCloseContext(
 ### Individual Transformation Focus
 Each constructor call gets its own complete open/close pair, providing granular visibility into every transformation step.
 
-### Source Tracking  
-- **immanentSources**: Maps each constructor parameter to its source property (e.g., `'email' => 'UserInput::email'`)
-- **transcendentSources**: Maps injected services to their types (e.g., `'validator' => 'SemanticValidator'`)
-
-### Destination Prediction
-The close context includes next destination information, allowing the logger to predict the transformation chain's future path without executing it.
+### Source Tracking
+- **input**:  Maps each `#[Input]` constructor parameter to its source property (e.g., `'email' => 'UserInput::email'`)
+- **inject**: Maps `#[Inject]` parameters to their resolved service class (e.g., `'validator' => 'SemanticValidator'`)
 
 ### Schema Compliance
 All contexts extend `AbstractContext` and have associated JSON schemas for validation:
-- `metamorphosis-open.json` - Validates MetamorphosisOpenContext
-- `metamorphosis-close.json` - Validates MetamorphosisCloseContext
+- `being-open.json`        — Validates `BeingOpenContext`
+- `being-final-open.json`  — Validates `BeingFinalOpenContext`
+- `being-close.json`       — Validates `BeingCloseContext`
+- `being-final-close.json` — Validates `BeingFinalCloseContext`
+- `being-error-close.json` — Validates `BeingErrorCloseContext`
+- `becoming-open.json`     — Validates `BecomingOpenContext` (chain wrapper)
+- `becoming-close.json`    — Validates `BecomingCloseContext` (chain wrapper)
 
 ## Implementation Notes
 
 ### Logger Integration
 The Be Framework's `Logger` class wraps `koriym/semantic-logger` and automatically:
-- Extracts constructor arguments before instantiation
-- Maps immanent sources from object properties
-- Detects transcendent sources from injected objects
-- Determines next destination from `#[Be]` attributes
-- Handles error cases with `DestinationNotFound`
+- Receives resolved constructor arguments from `Being::performSingleTransformation`
+- Maps immanent sources (`#[Input]`) by walking the target constructor
+- Detects transcendent sources (`#[Inject]`) from resolved argument objects
+- Picks `BeingOpenContext` vs `BeingFinalOpenContext` by reflecting on the target's `#[Be]` attribute
+- Picks the close context by reflecting on the produced result's `#[Be]` attribute
 
-### Limitations
-- @todo Currently only logs string-based single transformations 
-- @todo Array-based branching transformations (`#[Be([A::class, B::class])]`) are skipped
-- @todo Source mapping uses value equality, which may not work for complex objects
+Argument resolution runs **before** `logger->open`. If resolution throws
+(e.g. `SemanticVariableException`, `UnbecomingException`), no span is opened —
+a candidate that cannot open its span should not leave a ghost span behind.
 
 ### Log Output Structure
 The semantic logger produces a hierarchical JSON structure where each transformation appears as a nested open/close pair, providing complete traceability of the metamorphosis chain.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,8 +10,3 @@ parameters:
     - identifier: return.phpDocType
     - identifier: property.phpDocType
     - identifier: missingType.iterableValue
-    # ReflectionMethod::invoke() throws exceptions from invoked methods,
-    # but PHPStan cannot trace through reflection calls
-    -
-        identifier: catch.neverThrown
-        path: src/SemanticVariable/SemanticValidator.php

--- a/src/Becoming.php
+++ b/src/Becoming.php
@@ -11,6 +11,7 @@ use Koriym\SemanticLogger\SemanticLogger;
 use Override;
 use Ray\Di\Di\Named;
 use Ray\Di\InjectorInterface;
+use Throwable;
 
 /**
  * The Be Framework - Metamorphic Programming Engine
@@ -20,6 +21,7 @@ use Ray\Di\InjectorInterface;
 final class Becoming implements BecomingInterface
 {
     private Being $being;
+    private LoggerInterface $logger;
 
     public function __construct(
         InjectorInterface $injector,
@@ -30,6 +32,7 @@ final class Becoming implements BecomingInterface
     ) {
         $becomingArguments ??= new BecomingArguments($injector, new SemanticValidator($semanticNamespace));
         $logger ??= new Logger(new SemanticLogger(), $becomingArguments);
+        $this->logger = $logger;
         $this->being = new Being($logger, $becomingArguments, new BecomingType());
     }
 
@@ -46,13 +49,22 @@ final class Becoming implements BecomingInterface
     #[Override]
     public function __invoke(object $input): object
     {
+        $chainId = $this->logger->openChain($input);
         $current = $input;
 
-        // Being reveals its becoming, then becomes it
-        while ($nextForm = $this->being->willBe($current)) {
-            $current = $this->being->metamorphose($current, $nextForm);
-        }
+        try {
+            // Being reveals its becoming, then becomes it
+            while ($nextForm = $this->being->willBe($current)) {
+                $current = $this->being->metamorphose($current, $nextForm);
+            }
 
-        return $current;
+            $this->logger->closeChain($current, $chainId);
+
+            return $current;
+        } catch (Throwable $e) {
+            $this->logger->closeChain(null, $chainId, $e);
+
+            throw $e;
+        }
     }
 }

--- a/src/Becoming.php
+++ b/src/Becoming.php
@@ -57,14 +57,22 @@ final class Becoming implements BecomingInterface
             while ($nextForm = $this->being->willBe($current)) {
                 $current = $this->being->metamorphose($current, $nextForm);
             }
-
-            $this->logger->closeChain($current, $chainId);
-
-            return $current;
         } catch (Throwable $e) {
-            $this->logger->closeChain(null, $chainId, $e);
+            try {
+                $this->logger->closeChain(null, $chainId, $e);
+            } catch (Throwable) {
+                // A failure inside error logging must not mask the original
+                // metamorphosis exception. Swallow the logging error and
+                // rethrow the real one.
+            }
 
             throw $e;
         }
+
+        // Success close is outside the try so a logging failure here is not
+        // mis-reported as a metamorphosis failure.
+        $this->logger->closeChain($current, $chainId);
+
+        return $current;
     }
 }

--- a/src/Being.php
+++ b/src/Being.php
@@ -75,10 +75,14 @@ final class Being
      */
     private function performSingleTransformation(object $current, string $becoming): object
     {
-        $openId = $this->logger->open($current, $becoming);
+        // Resolve args BEFORE opening the span. If argument resolution throws
+        // (e.g. SemanticVariableException, UnbecomingException), no span is opened
+        // for this candidate — a candidate that cannot even open its span should
+        // not leave a ghost span in the log.
+        $args = $this->becomingArguments->be($current, $becoming);
+        $openId = $this->logger->open($current, $becoming, $args);
 
         try {
-            $args = $this->becomingArguments->be($current, $becoming);
             $result = (new ReflectionClass($becoming))->newInstanceArgs($args);
 
             $this->logger->close($result, $openId);

--- a/src/Module/BeModule.php
+++ b/src/Module/BeModule.php
@@ -26,6 +26,7 @@ final class BeModule extends AbstractModule
         parent::__construct($module);
     }
 
+    #[\Override]
     public function configure(): void
     {
         $this->bind(BecomingArgumentsInterface::class)->to(BecomingArguments::class);

--- a/src/Module/BeModule.php
+++ b/src/Module/BeModule.php
@@ -16,6 +16,7 @@ use Be\Framework\SemanticVariable\SemanticValidator;
 use Be\Framework\SemanticVariable\SemanticValidatorInterface;
 use Koriym\SemanticLogger\SemanticLogger;
 use Koriym\SemanticLogger\SemanticLoggerInterface;
+use Override;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
 
@@ -26,7 +27,7 @@ final class BeModule extends AbstractModule
         parent::__construct($module);
     }
 
-    #[\Override]
+    #[Override]
     public function configure(): void
     {
         $this->bind(BecomingArgumentsInterface::class)->to(BecomingArguments::class);

--- a/src/SemanticLog/Context/BecomingCloseContext.php
+++ b/src/SemanticLog/Context/BecomingCloseContext.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\SemanticLog\Context;
+
+use JsonSerializable;
+use Koriym\SemanticLogger\AbstractContext;
+use Override;
+
+/**
+ * Close context for the whole metamorphosis chain.
+ *
+ * Emitted when the chain terminates — either because it reached a being with
+ * no further #[Be], or because a transformation threw. Carries the final FQCN
+ * (or null when the chain failed before reaching a terminal being) and, when
+ * relevant, the exception that ended the chain.
+ */
+final class BecomingCloseContext extends AbstractContext implements JsonSerializable
+{
+    public const string TYPE = 'becoming_close';
+
+    public const string SCHEMA_URL = 'https://be-framework.org/schemas/becoming-close.json';
+
+    /**
+     * @param class-string|null $final   FQCN of the terminal being, or null if the chain failed.
+     * @param string|null       $error   FQCN of the thrown exception, or null on success.
+     * @param string|null       $message Exception message, or null on success.
+     */
+    public function __construct(
+        public readonly string|null $final = null,
+        public readonly string|null $error = null,
+        public readonly string|null $message = null,
+    ) {
+    }
+
+    /** @return array<string, string|null> */
+    #[Override]
+    public function jsonSerialize(): array
+    {
+        $payload = [];
+        if ($this->final !== null) {
+            $payload['final'] = $this->final;
+        }
+
+        if ($this->error !== null) {
+            $payload['error'] = $this->error;
+            $payload['message'] = $this->message ?? '';
+        }
+
+        return $payload;
+    }
+}

--- a/src/SemanticLog/Context/BecomingOpenContext.php
+++ b/src/SemanticLog/Context/BecomingOpenContext.php
@@ -4,21 +4,16 @@ declare(strict_types=1);
 
 namespace Be\Framework\SemanticLog\Context;
 
-use Be\Framework\Types;
 use JsonSerializable;
 use Koriym\SemanticLogger\AbstractContext;
 use Override;
-use stdClass;
 
 /**
- * Context for transformation start (Open context)
+ * Open context for the whole metamorphosis chain.
  *
- * Captures what the current being is trying to become, along with the
- * inputs it will receive and the services it will be injected with.
- *
- * @psalm-import-type ImmanentSources from Types
- * @psalm-import-type TranscendentSources from Types
- * @psalm-import-type ObjectProperties from Types
+ * Wraps every being_open/being_*_close pair into a single root so
+ * sequential transformations appear as sibling children of one outer span,
+ * rather than as disconnected top-level operations.
  */
 final class BecomingOpenContext extends AbstractContext implements JsonSerializable
 {
@@ -26,29 +21,18 @@ final class BecomingOpenContext extends AbstractContext implements JsonSerializa
 
     public const string SCHEMA_URL = 'https://be-framework.org/schemas/becoming-open.json';
 
-    /**
-     * @param class-string        $from   Class being transformed from
-     * @param string              $be     Target class string — single FQCN, or pipe-joined FQCNs for multi-candidate
-     * @param ImmanentSources     $input  #[Input] parameter names mapped to their origin path on the previous being
-     * @param TranscendentSources $inject #[Inject] parameter names mapped to the interface / service identifier from DI
-     */
+    /** @param class-string $input FQCN of the initial input being that starts the chain. */
     public function __construct(
-        public readonly string $from,
-        public readonly string $be,
-        public readonly array $input = [],
-        public readonly array $inject = [],
+        public readonly string $input,
     ) {
     }
 
-    /** @return ObjectProperties */
+    /** @return array{input: string} */
     #[Override]
     public function jsonSerialize(): array
     {
         return [
-            'from' => $this->from,
-            'be' => $this->be,
-            'input' => empty($this->input) ? new stdClass() : (object) $this->input,
-            'inject' => empty($this->inject) ? new stdClass() : (object) $this->inject,
+            'input' => $this->input,
         ];
     }
 }

--- a/src/SemanticLog/Context/BeingCloseContext.php
+++ b/src/SemanticLog/Context/BeingCloseContext.php
@@ -18,11 +18,11 @@ use stdClass;
  *
  * @psalm-import-type ObjectProperties from Types
  */
-final class BecomingBeingContext extends AbstractContext implements JsonSerializable
+final class BeingCloseContext extends AbstractContext implements JsonSerializable
 {
-    public const string TYPE = 'becoming_being';
+    public const string TYPE = 'being_close';
 
-    public const string SCHEMA_URL = 'https://be-framework.org/schemas/becoming-being.json';
+    public const string SCHEMA_URL = 'https://be-framework.org/schemas/being-close.json';
 
     /**
      * @param class-string     $being Class FQCN of the new being (the instantiated result)

--- a/src/SemanticLog/Context/BeingErrorCloseContext.php
+++ b/src/SemanticLog/Context/BeingErrorCloseContext.php
@@ -11,11 +11,11 @@ use Override;
 /**
  * Close context: the metamorphosis failed with a thrown exception.
  */
-final class BecomingErrorContext extends AbstractContext implements JsonSerializable
+final class BeingErrorCloseContext extends AbstractContext implements JsonSerializable
 {
-    public const string TYPE = 'becoming_error';
+    public const string TYPE = 'being_error_close';
 
-    public const string SCHEMA_URL = 'https://be-framework.org/schemas/becoming-error.json';
+    public const string SCHEMA_URL = 'https://be-framework.org/schemas/being-error-close.json';
 
     /**
      * @param string $error   Fully-qualified class name of the thrown exception

--- a/src/SemanticLog/Context/BeingFinalCloseContext.php
+++ b/src/SemanticLog/Context/BeingFinalCloseContext.php
@@ -15,11 +15,11 @@ use stdClass;
  *
  * @psalm-import-type ObjectProperties from Types
  */
-final class BecomingFinalContext extends AbstractContext implements JsonSerializable
+final class BeingFinalCloseContext extends AbstractContext implements JsonSerializable
 {
-    public const string TYPE = 'becoming_final';
+    public const string TYPE = 'being_final_close';
 
-    public const string SCHEMA_URL = 'https://be-framework.org/schemas/becoming-final.json';
+    public const string SCHEMA_URL = 'https://be-framework.org/schemas/being-final-close.json';
 
     /**
      * @param class-string     $final Class FQCN of the terminal being

--- a/src/SemanticLog/Context/BeingFinalCloseContext.php
+++ b/src/SemanticLog/Context/BeingFinalCloseContext.php
@@ -22,22 +22,30 @@ final class BeingFinalCloseContext extends AbstractContext implements JsonSerial
     public const string SCHEMA_URL = 'https://be-framework.org/schemas/being-final-close.json';
 
     /**
-     * @param class-string     $final Class FQCN of the terminal being
-     * @param ObjectProperties $prop  Properties of the terminal being
+     * @param class-string          $final Class FQCN of the terminal being
+     * @param ObjectProperties      $prop  Properties of the terminal being
+     * @param list<AbstractContext> $been  Events the terminal being curated into its own `$been` carrier (empty when it doesn't hold one)
      */
     public function __construct(
         public readonly string $final,
         public readonly array $prop,
+        public readonly array $been = [],
     ) {
     }
 
-    /** @return array{final: string, prop: object} */
+    /** @return array<string, mixed> */
     #[Override]
     public function jsonSerialize(): array
     {
-        return [
+        $payload = [
             'final' => $this->final,
             'prop' => empty($this->prop) ? new stdClass() : (object) $this->prop,
         ];
+
+        if ($this->been !== []) {
+            $payload['been'] = $this->been;
+        }
+
+        return $payload;
     }
 }

--- a/src/SemanticLog/Context/BeingFinalOpenContext.php
+++ b/src/SemanticLog/Context/BeingFinalOpenContext.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\SemanticLog\Context;
+
+use Be\Framework\Types;
+use JsonSerializable;
+use Koriym\SemanticLogger\AbstractContext;
+use Override;
+use stdClass;
+
+/**
+ * Open context for a terminal being — the target class has no #[Be] attribute,
+ * so this metamorphosis step produces the final being of the chain.
+ *
+ * Captures what the current being is trying to become, along with the inputs it will
+ * receive and the services it will be injected with.
+ *
+ * @psalm-import-type ImmanentSources from Types
+ * @psalm-import-type TranscendentSources from Types
+ * @psalm-import-type ObjectProperties from Types
+ */
+final class BeingFinalOpenContext extends AbstractContext implements JsonSerializable
+{
+    public const string TYPE = 'being_final_open';
+
+    public const string SCHEMA_URL = 'https://be-framework.org/schemas/being-final-open.json';
+
+    /**
+     * @param class-string        $from   Class being transformed from
+     * @param class-string        $be     Target class FQCN for the next metamorphosis
+     * @param ImmanentSources     $input  #[Input] parameter names mapped to their origin path on the previous being
+     * @param TranscendentSources $inject #[Inject] parameter names mapped to the interface / service identifier from DI
+     */
+    public function __construct(
+        public readonly string $from,
+        public readonly string $be,
+        public readonly array $input = [],
+        public readonly array $inject = [],
+    ) {
+    }
+
+    /** @return ObjectProperties */
+    #[Override]
+    public function jsonSerialize(): array
+    {
+        return [
+            'from' => $this->from,
+            'be' => $this->be,
+            'input' => empty($this->input) ? new stdClass() : (object) $this->input,
+            'inject' => empty($this->inject) ? new stdClass() : (object) $this->inject,
+        ];
+    }
+}

--- a/src/SemanticLog/Context/BeingFinalOpenContext.php
+++ b/src/SemanticLog/Context/BeingFinalOpenContext.php
@@ -29,13 +29,13 @@ final class BeingFinalOpenContext extends AbstractContext implements JsonSeriali
 
     /**
      * @param class-string        $from   Class being transformed from
-     * @param class-string        $be     Target class FQCN for the next metamorphosis
+     * @param class-string        $final  Target class FQCN — the terminal being this step lands on
      * @param ImmanentSources     $input  #[Input] parameter names mapped to their origin path on the previous being
      * @param TranscendentSources $inject #[Inject] parameter names mapped to the interface / service identifier from DI
      */
     public function __construct(
         public readonly string $from,
-        public readonly string $be,
+        public readonly string $final,
         public readonly array $input = [],
         public readonly array $inject = [],
     ) {
@@ -47,7 +47,7 @@ final class BeingFinalOpenContext extends AbstractContext implements JsonSeriali
     {
         return [
             'from' => $this->from,
-            'be' => $this->be,
+            'final' => $this->final,
             'input' => empty($this->input) ? new stdClass() : (object) $this->input,
             'inject' => empty($this->inject) ? new stdClass() : (object) $this->inject,
         ];

--- a/src/SemanticLog/Context/BeingOpenContext.php
+++ b/src/SemanticLog/Context/BeingOpenContext.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\SemanticLog\Context;
+
+use Be\Framework\Types;
+use JsonSerializable;
+use Koriym\SemanticLogger\AbstractContext;
+use Override;
+use stdClass;
+
+/**
+ * Open context for an intermediate being — the target class carries a #[Be] attribute,
+ * so the metamorphosis will continue with another step after this one.
+ *
+ * Captures what the current being is trying to become, along with the inputs it will
+ * receive and the services it will be injected with.
+ *
+ * @psalm-import-type ImmanentSources from Types
+ * @psalm-import-type TranscendentSources from Types
+ * @psalm-import-type ObjectProperties from Types
+ */
+final class BeingOpenContext extends AbstractContext implements JsonSerializable
+{
+    public const string TYPE = 'being_open';
+
+    public const string SCHEMA_URL = 'https://be-framework.org/schemas/being-open.json';
+
+    /**
+     * @param class-string        $from   Class being transformed from
+     * @param class-string        $be     Target class FQCN for the next metamorphosis
+     * @param ImmanentSources     $input  #[Input] parameter names mapped to their origin path on the previous being
+     * @param TranscendentSources $inject #[Inject] parameter names mapped to the interface / service identifier from DI
+     */
+    public function __construct(
+        public readonly string $from,
+        public readonly string $be,
+        public readonly array $input = [],
+        public readonly array $inject = [],
+    ) {
+    }
+
+    /** @return ObjectProperties */
+    #[Override]
+    public function jsonSerialize(): array
+    {
+        return [
+            'from' => $this->from,
+            'be' => $this->be,
+            'input' => empty($this->input) ? new stdClass() : (object) $this->input,
+            'inject' => empty($this->inject) ? new stdClass() : (object) $this->inject,
+        ];
+    }
+}

--- a/src/SemanticLog/Logger.php
+++ b/src/SemanticLog/Logger.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Be\Framework\SemanticLog;
 
+use Be\Framework\Attribute\Be;
 use Be\Framework\BecomingArgumentsInterface;
 use Be\Framework\BecomingType;
 use Be\Framework\Being;
-use Be\Framework\SemanticLog\Context\BecomingBeingContext;
-use Be\Framework\SemanticLog\Context\BecomingErrorContext;
-use Be\Framework\SemanticLog\Context\BecomingFinalContext;
+use Be\Framework\SemanticLog\Context\BecomingCloseContext;
 use Be\Framework\SemanticLog\Context\BecomingOpenContext;
+use Be\Framework\SemanticLog\Context\BeingCloseContext;
+use Be\Framework\SemanticLog\Context\BeingErrorCloseContext;
+use Be\Framework\SemanticLog\Context\BeingFinalCloseContext;
+use Be\Framework\SemanticLog\Context\BeingFinalOpenContext;
+use Be\Framework\SemanticLog\Context\BeingOpenContext;
 use JsonException;
 use Koriym\SemanticLogger\SemanticLoggerInterface;
 use Override;
@@ -21,11 +25,9 @@ use Throwable;
 
 use function array_filter;
 use function array_key_exists;
-use function array_keys;
 use function get_debug_type;
 use function get_object_vars;
 use function gettype;
-use function implode;
 use function is_array;
 use function is_bool;
 use function is_numeric;
@@ -56,23 +58,55 @@ final class Logger implements LoggerInterface
     }
 
     /**
-     * Log transformation start
-     *
-     * @param QualifiedClassName|QualifiedClasses $becoming
-     * @phpstan-param string|array<string> $becoming
+     * Open the outer span wrapping the whole metamorphosis chain.
      */
     #[Override]
-    public function open(object $current, string|array $becoming): string
+    public function openChain(object $input): string
+    {
+        return $this->logger->open(new BecomingOpenContext(
+            input: $input::class,
+        ));
+    }
+
+    /**
+     * Close the outer chain span.
+     */
+    #[Override]
+    public function closeChain(object|null $final, string $openId, Throwable|null $exception = null): void
+    {
+        if ($openId === '') {
+            return;
+        }
+
+        if ($exception !== null) {
+            $this->logger->close(new BecomingCloseContext(
+                error: $exception::class,
+                message: $exception->getMessage(),
+            ), $openId);
+
+            return;
+        }
+
+        $this->logger->close(new BecomingCloseContext(
+            final: $final !== null ? $final::class : null,
+        ), $openId);
+    }
+
+    /**
+     * Log transformation start
+     *
+     * @param class-string         $becoming
+     * @param array<string, mixed> $args
+     */
+    #[Override]
+    public function open(object $current, string $becoming, array $args): string
     {
         $fromClass = $current::class;
+        $input = $this->extractImmanentSources($current, $args, $becoming);
+        $inject = $this->extractTranscendentSources($args, $becoming);
 
-        if (is_string($becoming)) {
-            // Single transformation case
-            $args = $this->becomingArguments->be($current, $becoming);
-            $input = $this->extractImmanentSources($current, $args, $becoming);
-            $inject = $this->extractTranscendentSources($args, $becoming);
-
-            return $this->logger->open(new BecomingOpenContext(
+        if ($this->targetHasBeAttribute($becoming)) {
+            return $this->logger->open(new BeingOpenContext(
                 from: $fromClass,
                 be: $becoming,
                 input: $input,
@@ -80,12 +114,11 @@ final class Logger implements LoggerInterface
             ));
         }
 
-        // Array transformation case — log the attempt with pipe-joined candidate classes
-        return $this->logger->open(new BecomingOpenContext(
+        return $this->logger->open(new BeingFinalOpenContext(
             from: $fromClass,
-            be: implode('|', $becoming),
-            input: [],
-            inject: [],
+            be: $becoming,
+            input: $input,
+            inject: $inject,
         ));
     }
 
@@ -100,7 +133,7 @@ final class Logger implements LoggerInterface
         }
 
         if ($exception !== null) {
-            $this->logger->close(new BecomingErrorContext(
+            $this->logger->close(new BeingErrorCloseContext(
                 error: $exception::class,
                 message: $exception->getMessage(),
             ), $openId);
@@ -110,7 +143,7 @@ final class Logger implements LoggerInterface
 
         if ($result === null) {
             // Legacy safety net: null result without an exception still ends the open entry.
-            $this->logger->close(new BecomingErrorContext(
+            $this->logger->close(new BeingErrorCloseContext(
                 error: 'UnknownError',
                 message: 'Unknown error',
             ), $openId);
@@ -122,7 +155,7 @@ final class Logger implements LoggerInterface
         $nextBecoming = $this->being->willBe($result);
 
         if ($nextBecoming === null) {
-            $this->logger->close(new BecomingFinalContext(
+            $this->logger->close(new BeingFinalCloseContext(
                 prop: $prop,
                 final: $result::class,
             ), $openId);
@@ -130,10 +163,18 @@ final class Logger implements LoggerInterface
             return;
         }
 
-        $this->logger->close(new BecomingBeingContext(
+        $this->logger->close(new BeingCloseContext(
             prop: $prop,
             being: $result::class,
         ), $openId);
+    }
+
+    /** @param class-string $becoming */
+    private function targetHasBeAttribute(string $becoming): bool
+    {
+        $reflection = new ReflectionClass($becoming);
+
+        return $reflection->getAttributes(Be::class) !== [];
     }
 
     /**
@@ -240,7 +281,7 @@ final class Logger implements LoggerInterface
      * and dynamic properties (stdClass, objects with __set).
      *
      * @return ObjectProperties
-     * @phpstan-return array<string, mixed>
+     * @phpstan-return array<array-key, mixed>
      */
     private function extractProperties(object $result): array
     {
@@ -278,6 +319,7 @@ final class Logger implements LoggerInterface
                 continue;
             }
 
+            /** @psalm-suppress MixedAssignment */
             $properties[$name] = $value;
         }
 

--- a/src/SemanticLog/Logger.php
+++ b/src/SemanticLog/Logger.php
@@ -16,6 +16,7 @@ use Be\Framework\SemanticLog\Context\BeingFinalCloseContext;
 use Be\Framework\SemanticLog\Context\BeingFinalOpenContext;
 use Be\Framework\SemanticLog\Context\BeingOpenContext;
 use JsonException;
+use Koriym\SemanticLogger\AbstractContext;
 use Koriym\SemanticLogger\SemanticLoggerInterface;
 use Override;
 use Ray\Di\Di\Inject;
@@ -116,7 +117,7 @@ final class Logger implements LoggerInterface
 
         return $this->logger->open(new BeingFinalOpenContext(
             from: $fromClass,
-            be: $becoming,
+            final: $becoming,
             input: $input,
             inject: $inject,
         ));
@@ -156,8 +157,9 @@ final class Logger implements LoggerInterface
 
         if ($nextBecoming === null) {
             $this->logger->close(new BeingFinalCloseContext(
-                prop: $prop,
                 final: $result::class,
+                prop: $prop,
+                been: $this->extractBeenEvents($result),
             ), $openId);
 
             return;
@@ -272,6 +274,41 @@ final class Logger implements LoggerInterface
         }
 
         return $transcendentSources;
+    }
+
+    /**
+     * Extract the event list curated by the terminal being into its own `Been`.
+     *
+     * A Final class may accept a `Been` via `#[Inject]` and grow it with `with()`
+     * calls inside its constructor. Those calls write to the live semantic logger
+     * AND accumulate on the returned `Been`. We reflect on the result to surface
+     * those curated events on the `being_final_close` span — the logger reference
+     * stays behind since only the events belong in the log payload.
+     *
+     * Returns `[]` when the result carries no `Been` property, or when the
+     * carrier is empty.
+     *
+     * @return list<AbstractContext>
+     */
+    private function extractBeenEvents(object $result): array
+    {
+        foreach ((new ReflectionClass($result))->getProperties() as $property) {
+            if (! $property->isPublic() || $property->isStatic()) {
+                continue;
+            }
+
+            if (! $property->isInitialized($result)) {
+                continue;
+            }
+
+            /** @psalm-suppress MixedAssignment */
+            $value = $property->getValue($result);
+            if ($value instanceof Been) {
+                return $value->events;
+            }
+        }
+
+        return [];
     }
 
     /**

--- a/src/SemanticLog/Logger.php
+++ b/src/SemanticLog/Logger.php
@@ -18,6 +18,7 @@ use Be\Framework\SemanticLog\Context\BeingOpenContext;
 use JsonException;
 use Koriym\SemanticLogger\AbstractContext;
 use Koriym\SemanticLogger\SemanticLoggerInterface;
+use LogicException;
 use Override;
 use Ray\Di\Di\Inject;
 use Ray\InputQuery\Attribute\Input;
@@ -71,6 +72,11 @@ final class Logger implements LoggerInterface
 
     /**
      * Close the outer chain span.
+     *
+     * @throws LogicException When called with neither a terminal being nor an
+     *                        exception — the close payload has no valid shape
+     *                        under the `oneOf` constraint in
+     *                        `becoming-close.json`, so we refuse to emit one.
      */
     #[Override]
     public function closeChain(object|null $final, string $openId, Throwable|null $exception = null): void
@@ -88,8 +94,14 @@ final class Logger implements LoggerInterface
             return;
         }
 
+        if ($final === null) {
+            throw new LogicException(
+                'Logger::closeChain() requires a terminal being on success; got null with no exception.',
+            );
+        }
+
         $this->logger->close(new BecomingCloseContext(
-            final: $final !== null ? $final::class : null,
+            final: $final::class,
         ), $openId);
     }
 

--- a/src/SemanticLog/LoggerInterface.php
+++ b/src/SemanticLog/LoggerInterface.php
@@ -13,21 +13,45 @@ use Throwable;
  * Simple open/close pattern for transformation logging.
  *
  * @psalm-import-type QualifiedClassName from Types
- * @psalm-import-type QualifiedClasses from Types
+ * @psalm-import-type ConstructorArguments from Types
  * @psalm-import-type LogContextId from Types
  */
 interface LoggerInterface
 {
     /**
+     * Log the start of a whole metamorphosis chain
+     *
+     * Opens an outer span that wraps every subsequent transformation so the
+     * resulting log tree has a single root with sibling children, rather than
+     * a forest of disconnected operations.
+     *
+     * @param object $input Initial input being that starts the chain
+     *
+     * @return string Open ID for correlating with closeChain
+     */
+    public function openChain(object $input): string;
+
+    /**
+     * Log the end of a whole metamorphosis chain
+     *
+     * @param object|null    $final     Terminal being reached on success; null if the chain failed
+     * @param string         $openId    Open ID from the corresponding openChain call
+     * @param Throwable|null $exception Exception that ended the chain, or null on success
+     */
+    public function closeChain(object|null $final, string $openId, Throwable|null $exception = null): void;
+
+    /**
      * Log transformation start
      *
-     * @param object                              $current  Current object being transformed
-     * @param QualifiedClassName|QualifiedClasses $becoming Target class(es) for transformation
-     * @phpstan-param string|array<string> $becoming
+     * @param object               $current  Current object being transformed
+     * @param QualifiedClassName   $becoming Target class for transformation
+     * @param ConstructorArguments $args     Pre-resolved constructor arguments for the target class
+     * @phpstan-param class-string $becoming
+     * @phpstan-param array<string, mixed> $args
      *
      * @return string Open ID for correlating with close
      */
-    public function open(object $current, string|array $becoming): string;
+    public function open(object $current, string $becoming, array $args): string;
 
     /**
      * Log transformation completion

--- a/src/SemanticVariable/SemanticValidationMethodResolver.php
+++ b/src/SemanticVariable/SemanticValidationMethodResolver.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\SemanticVariable;
+
+use Be\Framework\Attribute\Validate;
+use Be\Framework\Types;
+use Ray\Di\Di\Inject;
+use Ray\InputQuery\Attribute\Input;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionParameter;
+
+use function array_filter;
+use function array_key_exists;
+use function array_slice;
+use function array_values;
+use function count;
+use function end;
+use function explode;
+use function in_array;
+
+/**
+ * Resolves validation methods and their arguments from semantic classes.
+ *
+ * @psalm-import-type ParameterAttributes from Types
+ * @psalm-import-type ValidationArguments from Types
+ * @psalm-import-type ReflectionMethods from Types
+ */
+final class SemanticValidationMethodResolver
+{
+    public function hasInjectAttribute(ReflectionParameter $parameter): bool
+    {
+        return ! empty($parameter->getAttributes(Inject::class));
+    }
+
+    /** @return ParameterAttributes */
+    public function extractAttributeNames(ReflectionParameter $parameter): array
+    {
+        $attributeNames = [];
+
+        foreach ($parameter->getAttributes() as $attribute) {
+            $className = $attribute->getName();
+            if ($className === Input::class || $className === Inject::class) {
+                continue;
+            }
+
+            $parts = explode('\\', $className);
+            $attributeNames[] = end($parts);
+        }
+
+        return $attributeNames;
+    }
+
+    /**
+     * @param ParameterAttributes $parameterAttributes
+     * @param ValidationArguments $validationArgs
+     *
+     * @return ReflectionMethods
+     * @phpstan-return array<int, ReflectionMethod>
+     */
+    public function getMatchingValidationMethods(object $semanticClass, array $parameterAttributes, array $validationArgs): array
+    {
+        $reflection = new ReflectionClass($semanticClass);
+        $matchingMethods = [];
+
+        foreach ($reflection->getMethods() as $method) {
+            if (! $this->isMatchingValidationMethod($method, $parameterAttributes, $validationArgs)) {
+                continue;
+            }
+
+            $matchingMethods[] = $method;
+        }
+
+        return $matchingMethods;
+    }
+
+    /**
+     * @param array<string, mixed> $allArgs
+     *
+     * @return ValidationArguments|null
+     */
+    public function matchArgsByName(ReflectionMethod $method, array $allArgs): array|null
+    {
+        $nonInjectParams = $this->getNonInjectParameters($method);
+        if (count($nonInjectParams) < 2) {
+            return null;
+        }
+
+        $methodArgs = [];
+        foreach ($nonInjectParams as $param) {
+            if (! array_key_exists($param->getName(), $allArgs)) {
+                return null;
+            }
+
+            /** @psalm-suppress MixedAssignment */
+            $methodArgs[] = $allArgs[$param->getName()];
+        }
+
+        return $methodArgs;
+    }
+
+    /**
+     * @param ValidationArguments $inputArgs
+     *
+     * @return ValidationArguments
+     */
+    public function resolveMethodArguments(ReflectionMethod $method, array $inputArgs): array
+    {
+        return array_values(array_slice($inputArgs, 0, count($this->getNonInjectParameters($method))));
+    }
+
+    /**
+     * @param ParameterAttributes $parameterAttributes
+     * @param ValidationArguments $validationArgs
+     */
+    private function isMatchingValidationMethod(ReflectionMethod $method, array $parameterAttributes, array $validationArgs): bool
+    {
+        return $this->isValidateMethod($method)
+            && $this->hasEnoughArguments($method, $validationArgs)
+            && $this->matchesParameterAttributes($method, $parameterAttributes);
+    }
+
+    private function isValidateMethod(ReflectionMethod $method): bool
+    {
+        return ! empty($method->getAttributes(Validate::class));
+    }
+
+    /** @param ValidationArguments $validationArgs */
+    private function hasEnoughArguments(ReflectionMethod $method, array $validationArgs): bool
+    {
+        return count($validationArgs) >= count($this->getNonInjectParameters($method));
+    }
+
+    /** @param ParameterAttributes $parameterAttributes */
+    private function matchesParameterAttributes(ReflectionMethod $method, array $parameterAttributes): bool
+    {
+        foreach ($this->getNonInjectParameters($method) as $parameter) {
+            if (! $this->parameterAttributesMatch($parameter, $parameterAttributes)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /** @param ParameterAttributes $parameterAttributes */
+    private function parameterAttributesMatch(ReflectionParameter $parameter, array $parameterAttributes): bool
+    {
+        $requiredAttributes = $this->extractAttributeNames($parameter);
+        if ($requiredAttributes === []) {
+            return true;
+        }
+
+        foreach ($requiredAttributes as $attribute) {
+            if (in_array($attribute, $parameterAttributes, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @return list<ReflectionParameter> */
+    private function getNonInjectParameters(ReflectionMethod $method): array
+    {
+        $nonInjectParameters = array_values(array_filter(
+            $method->getParameters(),
+            fn (ReflectionParameter $parameter): bool => ! $this->hasInjectAttribute($parameter),
+        ));
+
+        /** @var list<ReflectionParameter> $nonInjectParameters */
+        return $nonInjectParameters;
+    }
+}

--- a/src/SemanticVariable/SemanticValidator.php
+++ b/src/SemanticVariable/SemanticValidator.php
@@ -9,22 +9,16 @@ use Be\Framework\Exception\SemanticVariableException;
 use Be\Framework\Types;
 use DomainException;
 use Override;
-use Ray\Di\Di\Inject;
 use Ray\Di\Di\Named;
-use Ray\InputQuery\Attribute\Input;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionParameter;
 
-use function array_filter;
 use function array_key_exists;
-use function array_values;
 use function class_exists;
-use function count;
-use function end;
-use function explode;
 use function get_object_vars;
 use function in_array;
+use function is_array;
 use function str_replace;
 use function trigger_error;
 use function ucwords;
@@ -45,10 +39,26 @@ use const E_USER_NOTICE;
  */
 final class SemanticValidator implements SemanticValidatorInterface
 {
+    /** @var array<string, class-string> */
+    private readonly array $classMap;
+    private readonly SemanticValidationMethodResolver $validationMethodResolver;
+
+    /** @param array<string, class-string>|SemanticValidationMethodResolver|null $classMapOrValidationMethodResolver */
     public function __construct(
         #[Named('semantic_namespace')]
         private readonly string $semanticNamespace,
+        array|SemanticValidationMethodResolver|null $classMapOrValidationMethodResolver = null,
+        SemanticValidationMethodResolver|null $validationMethodResolver = null,
     ) {
+        if ($classMapOrValidationMethodResolver instanceof SemanticValidationMethodResolver) {
+            $this->classMap = [];
+            $this->validationMethodResolver = $classMapOrValidationMethodResolver;
+
+            return;
+        }
+
+        $this->classMap = is_array($classMapOrValidationMethodResolver) ? $classMapOrValidationMethodResolver : [];
+        $this->validationMethodResolver = $validationMethodResolver ?? new SemanticValidationMethodResolver();
     }
 
     /**
@@ -70,7 +80,7 @@ final class SemanticValidator implements SemanticValidatorInterface
 
         foreach ($constructor->getParameters() as $parameter) {
             // Skip #[Inject] parameters
-            if ($this->hasInjectAttribute($parameter)) {
+            if ($this->validationMethodResolver->hasInjectAttribute($parameter)) {
                 continue;
             }
 
@@ -83,7 +93,7 @@ final class SemanticValidator implements SemanticValidatorInterface
 
             /** @psalm-suppress MixedAssignment */
             $propertyValue = $objectProperties[$paramName];
-            $parameterAttributes = $this->extractAttributeNames($parameter);
+            $parameterAttributes = $this->validationMethodResolver->extractAttributeNames($parameter);
 
             // Validate property using semantic variable validation
             $errors = $this->validateWithAttributes($paramName, $parameterAttributes, $propertyValue);
@@ -101,6 +111,7 @@ final class SemanticValidator implements SemanticValidatorInterface
      *
      * @param ReflectionMethod     $method Method containing parameter definitions
      * @param ConstructorArguments $args   Values to validate (associative array: param_name => value)
+     * @phpstan-param array<string, mixed> $args
      *
      * @return Errors Validation errors (empty if validation passes)
      */
@@ -112,7 +123,7 @@ final class SemanticValidator implements SemanticValidatorInterface
         // First pass: single-field validation
         foreach ($method->getParameters() as $parameter) {
             // Skip #[Inject] parameters
-            if ($this->hasInjectAttribute($parameter)) {
+            if ($this->validationMethodResolver->hasInjectAttribute($parameter)) {
                 continue;
             }
 
@@ -140,6 +151,7 @@ final class SemanticValidator implements SemanticValidatorInterface
      *
      * @param ReflectionMethod     $method  Constructor with parameter definitions
      * @param ConstructorArguments $allArgs All constructor argument values
+     * @phpstan-param array<string, mixed> $allArgs
      *
      * @return list<DomainException>
      */
@@ -149,7 +161,7 @@ final class SemanticValidator implements SemanticValidatorInterface
         $checkedClasses = [];
 
         foreach ($method->getParameters() as $parameter) {
-            if ($this->hasInjectAttribute($parameter)) {
+            if ($this->validationMethodResolver->hasInjectAttribute($parameter)) {
                 continue;
             }
 
@@ -174,6 +186,7 @@ final class SemanticValidator implements SemanticValidatorInterface
      * Invoke multi-parameter #[Validate] methods whose parameter names match available args
      *
      * @param ConstructorArguments $allArgs All constructor argument values
+     * @phpstan-param array<string, mixed> $allArgs
      *
      * @return list<DomainException>
      */
@@ -187,7 +200,7 @@ final class SemanticValidator implements SemanticValidatorInterface
                 continue;
             }
 
-            $methodArgs = $this->matchArgsByName($validateMethod, $allArgs);
+            $methodArgs = $this->validationMethodResolver->matchArgsByName($validateMethod, $allArgs);
             if ($methodArgs === null) {
                 continue;
             }
@@ -203,40 +216,6 @@ final class SemanticValidator implements SemanticValidatorInterface
     }
 
     /**
-     * Match method parameters to available args by name
-     *
-     * Returns ordered argument values if all non-Inject parameters with 2+ params
-     * have matching names in $allArgs, or null if not matched.
-     *
-     * @param ConstructorArguments $allArgs All constructor argument values
-     *
-     * @return ValidationArguments|null
-     */
-    private function matchArgsByName(ReflectionMethod $method, array $allArgs): array|null
-    {
-        $nonInjectParams = array_values(array_filter(
-            $method->getParameters(),
-            static fn (ReflectionParameter $p) => empty($p->getAttributes(Inject::class)),
-        ));
-
-        if (count($nonInjectParams) < 2) {
-            return null;
-        }
-
-        $methodArgs = [];
-        foreach ($nonInjectParams as $param) {
-            if (! array_key_exists($param->getName(), $allArgs)) {
-                return null;
-            }
-
-            /** @psalm-suppress MixedAssignment */
-            $methodArgs[] = $allArgs[$param->getName()];
-        }
-
-        return $methodArgs;
-    }
-
-    /**
      * Validate single parameter (test convenience API)
      *
      * @param ReflectionParameter $parameter Parameter containing variable name and attributes
@@ -248,39 +227,9 @@ final class SemanticValidator implements SemanticValidatorInterface
     public function validateArg(ReflectionParameter $parameter, mixed $value): Errors
     {
         $variableName = $parameter->getName();
-        $attributes = $this->extractAttributeNames($parameter);
+        $attributes = $this->validationMethodResolver->extractAttributeNames($parameter);
 
         return $this->validateWithAttributes($variableName, $attributes, $value);
-    }
-
-    /**
-     * Check if parameter has #[Inject] attribute
-     */
-    private function hasInjectAttribute(ReflectionParameter $parameter): bool
-    {
-        return ! empty($parameter->getAttributes(Inject::class));
-    }
-
-    /**
-     * Extract attribute names from ReflectionParameter
-     *
-     * @return ParameterAttributes
-     */
-    private function extractAttributeNames(ReflectionParameter $parameter): array
-    {
-        $attributeNames = [];
-
-        foreach ($parameter->getAttributes() as $attribute) {
-            $className = $attribute->getName();
-            if ($className === Input::class || $className === Inject::class) {
-                continue; // Skip non-semantic attributes
-            }
-
-            $parts = explode('\\', $className);
-            $attributeNames[] = end($parts);
-        }
-
-        return $attributeNames;
     }
 
     /**
@@ -299,7 +248,7 @@ final class SemanticValidator implements SemanticValidatorInterface
             return new NullErrors();
         }
 
-        $validationMethods = $this->getMatchingValidationMethods($semanticClass, $parameterAttributes, $args);
+        $validationMethods = $this->validationMethodResolver->getMatchingValidationMethods($semanticClass, $parameterAttributes, $args);
 
         if (empty($validationMethods)) {
             // No matching validation methods found
@@ -310,7 +259,7 @@ final class SemanticValidator implements SemanticValidatorInterface
 
         foreach ($validationMethods as $method) {
             try {
-                $methodArgs = $this->resolveMethodArguments($method, $args);
+                $methodArgs = $this->validationMethodResolver->resolveMethodArguments($method, $args);
                 $method->invoke($semanticClass, ...$methodArgs);
             } catch (DomainException $exception) {
                 $exceptions[] = $exception;
@@ -326,7 +275,7 @@ final class SemanticValidator implements SemanticValidatorInterface
     private function resolveSemanticClass(string $variableName): object|null
     {
         $className = $this->convertToClassName($variableName);
-        $fullClassName = "{$this->semanticNamespace}\\$className";
+        $fullClassName = $this->classMap[$className] ?? "{$this->semanticNamespace}\\$className";
 
         if (! class_exists($fullClassName)) {
             trigger_error("Semantic variable '{$className}' not registered in ontology namespace {$this->semanticNamespace}", E_USER_NOTICE);
@@ -346,100 +295,6 @@ final class SemanticValidator implements SemanticValidatorInterface
     {
         // Convert snake_case to PascalCase
         return str_replace(' ', '', ucwords(str_replace('_', ' ', $variableName)));
-    }
-
-    /**
-     * Get validation methods with #[Validate] attribute that match the given arguments
-     *
-     * @param object              $semanticClass       The semantic validation class
-     * @param ParameterAttributes $parameterAttributes Parameter attributes for filtering
-     * @param ValidationArguments $validationArgs      Arguments to validate
-     *
-     * @return ReflectionMethods
-     * @phpstan-return array<int, ReflectionMethod>
-     */
-    private function getMatchingValidationMethods(object $semanticClass, array $parameterAttributes, array $validationArgs): array
-    {
-        $reflection = new ReflectionClass($semanticClass);
-        $methodsByName = [];
-
-        // Simple method matching: check each validation method's parameters
-        foreach ($reflection->getMethods() as $method) {
-            if (empty($method->getAttributes(Validate::class))) {
-                continue;
-            }
-
-            // Check if this method matches our input parameters
-            $methodParameters = $method->getParameters();
-            $matches = true;
-
-            $nonInjectParams = array_filter($methodParameters, static fn ($p) => empty($p->getAttributes(Inject::class)));
-
-            // Check if we have enough arguments for this method
-            if (count($validationArgs) < count($nonInjectParams)) {
-                continue;
-            }
-
-            foreach ($methodParameters as $methodParam) {
-                if ($methodParam->getAttributes(Inject::class)) {
-                    continue; // Skip injected parameters
-                }
-
-                // Check if parameter attributes match (if method param has semantic attributes)
-                $methodParamAttrs = $this->extractAttributeNames($methodParam);
-                if (! empty($methodParamAttrs)) {
-                    // Method parameter has attributes - input must have matching attributes
-                    $hasMatchingAttr = false;
-                    foreach ($methodParamAttrs as $attr) {
-                        if (in_array($attr, $parameterAttributes, true)) {
-                            $hasMatchingAttr = true;
-                            break;
-                        }
-                    }
-
-                    if (! $hasMatchingAttr) {
-                        $matches = false;
-                        break;
-                    }
-                }
-            }
-
-            if ($matches) {
-                $methodsByName[$method->getName()] = $method;
-            }
-        }
-
-        return array_values($methodsByName);
-    }
-
-    /**
-     * Resolve method arguments by extracting only the arguments needed for this method
-     *
-     * @param ValidationArguments $inputArgs
-     *
-     * @return ValidationArguments
-     */
-    private function resolveMethodArguments(ReflectionMethod $method, array $inputArgs): array
-    {
-        $resolvedArgs = [];
-        $paramIndex = 0;
-
-        foreach ($method->getParameters() as $param) {
-            // Skip injected parameters - they will be handled by DI
-            if (! empty($param->getAttributes(Inject::class))) {
-                continue;
-            }
-
-            // Take arguments in order for non-injected parameters
-            if ($paramIndex < count($inputArgs)) {
-                /** @psalm-suppress MixedAssignment */
-                $resolvedArgs[] = $inputArgs[$paramIndex];
-            }
-
-            $paramIndex++;
-        }
-
-        return $resolvedArgs;
     }
 
     /**
@@ -467,7 +322,6 @@ final class SemanticValidator implements SemanticValidatorInterface
         $allErrors = [];
 
         foreach ($reflection->getProperties() as $property) {
-            $property->setAccessible(true);
             /** @var mixed $value */
             $value = $property->getValue($object);
             $propertyName = $property->getName();

--- a/src/SemanticVariable/SemanticValidator.php
+++ b/src/SemanticVariable/SemanticValidator.php
@@ -414,22 +414,6 @@ final class SemanticValidator implements SemanticValidatorInterface
     }
 
     /**
-     * Check if a class is marked with SemanticTag attribute
-     *
-     * @phpstan-ignore method.unused
-     */
-    private function isSemanticTagClass(string $className): bool
-    {
-        if (! class_exists($className)) {
-            return false;
-        }
-
-        $reflection = new ReflectionClass($className);
-
-        return ! empty($reflection->getAttributes(SemanticTag::class));
-    }
-
-    /**
      * Resolve method arguments by extracting only the arguments needed for this method
      *
      * @param ValidationArguments $inputArgs

--- a/src/SemanticVariable/SemanticValidator.php
+++ b/src/SemanticVariable/SemanticValidator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Be\Framework\SemanticVariable;
 
-use Be\Framework\Attribute\SemanticTag;
 use Be\Framework\Attribute\Validate;
 use Be\Framework\Exception\SemanticVariableException;
 use Be\Framework\Types;

--- a/src/Types.php
+++ b/src/Types.php
@@ -32,7 +32,7 @@ namespace Be\Framework;
  *
  * Array domain types
  * @psalm-type ConstructorArguments = array<ParameterName, ConstructorArgumentValue>   Parameter-to-value map for object construction
- * @psalm-type ObjectProperties = array<PropertyName, PropertyValue>                   Property-to-value map of object properties (get_object_vars result)
+ * @psalm-type ObjectProperties = array<array-key, PropertyValue>                      Property-to-value map of object properties (get_object_vars result — keys may be int for numeric dynamic property names)
  * @psalm-type BecomingClasses = array<ClassName>                                      Array of class names for metamorphosis
  * @psalm-type QualifiedClasses = array<QualifiedClassName>                            Array of fully qualified class names
  * @psalm-type ImmanentSources = array<ParameterName, PropertyName>                    #[Input] parameter sources from object properties

--- a/tests/BecomingTypeAdvancedTest.php
+++ b/tests/BecomingTypeAdvancedTest.php
@@ -104,10 +104,11 @@ final class BecomingTypeAdvancedTest extends TestCase
             public string|null $name = null; // Actual value is null
         };
 
+        // Not nullable
         $targetClass = new class ('') {
             public function __construct(public string $name)
             {
-            } // Not nullable
+            }
         };
 
         $result = $this->becomingType->match($input, $targetClass::class);
@@ -145,10 +146,11 @@ final class BecomingTypeAdvancedTest extends TestCase
             }
         };
 
+        // Different class
         $targetClass = new class (new Exception()) {
             public function __construct(public Throwable $obj)
             {
-            } // Different class
+            }
         };
 
         $result = $this->becomingType->match($input, $targetClass::class);
@@ -268,21 +270,21 @@ final class BecomingTypeAdvancedTest extends TestCase
             public function __construct()
             {
                 $this->value = new class implements ArrayAccess, Countable {
-                    public function offsetExists($offset): bool
+                    public function offsetExists(mixed $offset): bool
                     {
                         return false;
                     }
 
-                    public function offsetGet($offset): mixed
+                    public function offsetGet(mixed $offset): mixed
                     {
                         return null;
                     }
 
-                    public function offsetSet($offset, $value): void
+                    public function offsetSet(mixed $offset, mixed $value): void
                     {
                     }
 
-                    public function offsetUnset($offset): void
+                    public function offsetUnset(mixed $offset): void
                     {
                     }
 
@@ -315,21 +317,21 @@ final class BecomingTypeAdvancedTest extends TestCase
             {
                 // Create an object that only implements ArrayAccess but not Countable
                 $this->value = new class implements ArrayAccess {
-                    public function offsetExists($offset): bool
+                    public function offsetExists(mixed $offset): bool
                     {
                         return false;
                     }
 
-                    public function offsetGet($offset): mixed
+                    public function offsetGet(mixed $offset): mixed
                     {
                         return null;
                     }
 
-                    public function offsetSet($offset, $value): void
+                    public function offsetSet(mixed $offset, mixed $value): void
                     {
                     }
 
-                    public function offsetUnset($offset): void
+                    public function offsetUnset(mixed $offset): void
                     {
                     }
                 };
@@ -339,21 +341,21 @@ final class BecomingTypeAdvancedTest extends TestCase
         // Target class requires both ArrayAccess AND Countable
         // Use a dummy object that implements both interfaces for constructor
         $dummy = new class implements ArrayAccess, Countable {
-            public function offsetExists($offset): bool
+            public function offsetExists(mixed $offset): bool
             {
                 return false;
             }
 
-            public function offsetGet($offset): mixed
+            public function offsetGet(mixed $offset): mixed
             {
                 return null;
             }
 
-            public function offsetSet($offset, $value): void
+            public function offsetSet(mixed $offset, mixed $value): void
             {
             }
 
-            public function offsetUnset($offset): void
+            public function offsetUnset(mixed $offset): void
             {
             }
 

--- a/tests/Integration/Ldd/RegisterUser/been.json
+++ b/tests/Integration/Ldd/RegisterUser/been.json
@@ -1,22 +1,34 @@
 {
     "$schema": "https://koriym.github.io/Koriym.SemanticLogger/schemas/combined.json",
-    "open": {
-        "id": "becoming_open_1",
-        "type": "becoming_open",
-        "schemaUrl": "https://be-framework.org/schemas/becoming-open.json",
-        "context": {
-            "from": "MyVendor\\MyApp\\Ldd\\RegisterUser\\UnverifiedEmail",
-            "be": "MyVendor\\MyApp\\Ldd\\RegisterUser\\RegisteredUser",
-            "input": {
-                "value": "MyVendor\\MyApp\\Ldd\\RegisterUser\\UnverifiedEmail::value"
+    "open": [
+        {
+            "id": "becoming_open_1",
+            "type": "becoming_open",
+            "schemaUrl": "https://be-framework.org/schemas/becoming-open.json",
+            "context": {
+                "input": "MyVendor\\MyApp\\Ldd\\RegisterUser\\UnverifiedEmail"
             },
-            "inject": {
-                "verifier": "MyVendor\\MyApp\\Ldd\\RegisterUser\\EmailVerifier",
-                "users": "MyVendor\\MyApp\\Ldd\\RegisterUser\\UserRepository",
-                "been": "Be\\Framework\\SemanticLog\\Been"
-            }
+            "open": [
+                {
+                    "id": "being_final_open_1",
+                    "type": "being_final_open",
+                    "schemaUrl": "https://be-framework.org/schemas/being-final-open.json",
+                    "context": {
+                        "from": "MyVendor\\MyApp\\Ldd\\RegisterUser\\UnverifiedEmail",
+                        "be": "MyVendor\\MyApp\\Ldd\\RegisterUser\\RegisteredUser",
+                        "input": {
+                            "value": "MyVendor\\MyApp\\Ldd\\RegisterUser\\UnverifiedEmail::value"
+                        },
+                        "inject": {
+                            "verifier": "MyVendor\\MyApp\\Ldd\\RegisterUser\\EmailVerifier",
+                            "users": "MyVendor\\MyApp\\Ldd\\RegisterUser\\UserRepository",
+                            "been": "Be\\Framework\\SemanticLog\\Been"
+                        }
+                    }
+                }
+            ]
         }
-    },
+    ],
     "events": [
         {
             "id": "email_format_asserted_1",
@@ -25,7 +37,7 @@
             "context": {
                 "email": "alice@example.com"
             },
-            "openId": "becoming_open_1"
+            "openId": "being_final_open_1"
         },
         {
             "id": "user_inserted_1",
@@ -35,20 +47,33 @@
                 "userId": 42,
                 "email": "alice@example.com"
             },
-            "openId": "becoming_open_1"
+            "openId": "being_final_open_1"
         }
     ],
-    "close": {
-        "id": "becoming_final_1",
-        "type": "becoming_final",
-        "schemaUrl": "https://be-framework.org/schemas/becoming-final.json",
-        "context": {
-            "final": "MyVendor\\MyApp\\Ldd\\RegisterUser\\RegisteredUser",
-            "prop": {
-                "userId": 42,
-                "value": "alice@example.com"
-            }
-        },
-        "openId": "becoming_open_1"
-    }
+    "close": [
+        {
+            "id": "becoming_close_1",
+            "type": "becoming_close",
+            "schemaUrl": "https://be-framework.org/schemas/becoming-close.json",
+            "context": {
+                "final": "MyVendor\\MyApp\\Ldd\\RegisterUser\\RegisteredUser"
+            },
+            "openId": "becoming_open_1",
+            "close": [
+                {
+                    "id": "being_final_close_1",
+                    "type": "being_final_close",
+                    "schemaUrl": "https://be-framework.org/schemas/being-final-close.json",
+                    "context": {
+                        "final": "MyVendor\\MyApp\\Ldd\\RegisterUser\\RegisteredUser",
+                        "prop": {
+                            "userId": 42,
+                            "value": "alice@example.com"
+                        }
+                    },
+                    "openId": "being_final_open_1"
+                }
+            ]
+        }
+    ]
 }

--- a/tests/Integration/Ldd/RegisterUser/been.json
+++ b/tests/Integration/Ldd/RegisterUser/been.json
@@ -15,7 +15,7 @@
                     "schemaUrl": "https://be-framework.org/schemas/being-final-open.json",
                     "context": {
                         "from": "MyVendor\\MyApp\\Ldd\\RegisterUser\\UnverifiedEmail",
-                        "be": "MyVendor\\MyApp\\Ldd\\RegisterUser\\RegisteredUser",
+                        "final": "MyVendor\\MyApp\\Ldd\\RegisterUser\\RegisteredUser",
                         "input": {
                             "value": "MyVendor\\MyApp\\Ldd\\RegisterUser\\UnverifiedEmail::value"
                         },
@@ -69,7 +69,16 @@
                         "prop": {
                             "userId": 42,
                             "value": "alice@example.com"
-                        }
+                        },
+                        "been": [
+                            {
+                                "email": "alice@example.com"
+                            },
+                            {
+                                "userId": 42,
+                                "email": "alice@example.com"
+                            }
+                        ]
                     },
                     "openId": "being_final_open_1"
                 }

--- a/tests/SemanticLog/JsonSchemaValidationTest.php
+++ b/tests/SemanticLog/JsonSchemaValidationTest.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Be\Framework\SemanticLog;
 
-use Be\Framework\SemanticLog\Context\BecomingBeingContext;
-use Be\Framework\SemanticLog\Context\BecomingErrorContext;
-use Be\Framework\SemanticLog\Context\BecomingFinalContext;
-use Be\Framework\SemanticLog\Context\BecomingOpenContext;
+use Be\Framework\SemanticLog\Context\BeingCloseContext;
+use Be\Framework\SemanticLog\Context\BeingErrorCloseContext;
+use Be\Framework\SemanticLog\Context\BeingFinalCloseContext;
+use Be\Framework\SemanticLog\Context\BeingFinalOpenContext;
+use Be\Framework\SemanticLog\Context\BeingOpenContext;
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Validator;
 use PHPUnit\Framework\TestCase;
@@ -27,23 +28,25 @@ final class JsonSchemaValidationTest extends TestCase
 {
     private Validator $validator;
     private object $openSchema;
-    private object $beingSchema;
-    private object $finalSchema;
-    private object $errorSchema;
+    private object $finalOpenSchema;
+    private object $closeSchema;
+    private object $finalCloseSchema;
+    private object $errorCloseSchema;
 
     protected function setUp(): void
     {
         $this->validator = new Validator();
 
-        $this->openSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/becoming-open.json'));
-        $this->beingSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/becoming-being.json'));
-        $this->finalSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/becoming-final.json'));
-        $this->errorSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/becoming-error.json'));
+        $this->openSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/being-open.json'));
+        $this->finalOpenSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/being-final-open.json'));
+        $this->closeSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/being-close.json'));
+        $this->finalCloseSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/being-final-close.json'));
+        $this->errorCloseSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/being-error-close.json'));
     }
 
-    public function testBecomingOpenContextValidatesAgainstSchema(): void
+    public function testBeingOpenContextValidatesAgainstSchema(): void
     {
-        $context = new BecomingOpenContext(
+        $context = new BeingOpenContext(
             from: 'Be\Framework\Test\UserInput',
             be: 'Be\Framework\Test\ValidatedUser',
             input: [
@@ -62,31 +65,31 @@ final class JsonSchemaValidationTest extends TestCase
 
         $this->assertTrue(
             $this->validator->isValid(),
-            'BecomingOpenContext should validate. Errors: ' . json_encode($this->validator->getErrors()),
+            'BeingOpenContext should validate. Errors: ' . json_encode($this->validator->getErrors()),
         );
     }
 
-    public function testBecomingOpenContextWithPipeJoinedBeValidates(): void
+    public function testBeingFinalOpenContextValidatesAgainstSchema(): void
     {
-        $context = new BecomingOpenContext(
+        $context = new BeingFinalOpenContext(
             from: 'Be\Framework\Test\ProcessingData',
-            be: 'Be\Framework\Test\Success|Be\Framework\Test\Failure',
+            be: 'Be\Framework\Test\TerminalResult',
             input: ['data' => 'ProcessingData::data'],
             inject: [],
         );
 
         $contextData = json_decode(json_encode($context), false);
-        $this->validator->validate($contextData, $this->openSchema, Constraint::CHECK_MODE_NORMAL);
+        $this->validator->validate($contextData, $this->finalOpenSchema, Constraint::CHECK_MODE_NORMAL);
 
         $this->assertTrue(
             $this->validator->isValid(),
-            'Pipe-joined be should validate. Errors: ' . json_encode($this->validator->getErrors()),
+            'BeingFinalOpenContext should validate. Errors: ' . json_encode($this->validator->getErrors()),
         );
     }
 
-    public function testBecomingOpenContextMinimalValidates(): void
+    public function testBeingOpenContextMinimalValidates(): void
     {
-        $context = new BecomingOpenContext(
+        $context = new BeingOpenContext(
             from: 'Be\Framework\Test\SimpleInput',
             be: 'Be\Framework\Test\SimpleOutput',
         );
@@ -100,9 +103,9 @@ final class JsonSchemaValidationTest extends TestCase
         );
     }
 
-    public function testBecomingBeingContextValidates(): void
+    public function testBeingCloseContextValidates(): void
     {
-        $context = new BecomingBeingContext(
+        $context = new BeingCloseContext(
             prop: [
                 'email' => 'user@example.com',
                 'validated' => true,
@@ -111,17 +114,17 @@ final class JsonSchemaValidationTest extends TestCase
         );
 
         $contextData = json_decode(json_encode($context), false);
-        $this->validator->validate($contextData, $this->beingSchema, Constraint::CHECK_MODE_NORMAL);
+        $this->validator->validate($contextData, $this->closeSchema, Constraint::CHECK_MODE_NORMAL);
 
         $this->assertTrue(
             $this->validator->isValid(),
-            'BecomingBeingContext should validate. Errors: ' . json_encode($this->validator->getErrors()),
+            'BeingCloseContext should validate. Errors: ' . json_encode($this->validator->getErrors()),
         );
     }
 
-    public function testBecomingFinalContextValidates(): void
+    public function testBeingFinalCloseContextValidates(): void
     {
-        $context = new BecomingFinalContext(
+        $context = new BeingFinalCloseContext(
             prop: [
                 'result' => 'success',
                 'data' => ['key' => 'value'],
@@ -130,27 +133,27 @@ final class JsonSchemaValidationTest extends TestCase
         );
 
         $contextData = json_decode(json_encode($context), false);
-        $this->validator->validate($contextData, $this->finalSchema, Constraint::CHECK_MODE_NORMAL);
+        $this->validator->validate($contextData, $this->finalCloseSchema, Constraint::CHECK_MODE_NORMAL);
 
         $this->assertTrue(
             $this->validator->isValid(),
-            'BecomingFinalContext should validate. Errors: ' . json_encode($this->validator->getErrors()),
+            'BeingFinalCloseContext should validate. Errors: ' . json_encode($this->validator->getErrors()),
         );
     }
 
-    public function testBecomingErrorContextValidates(): void
+    public function testBeingErrorCloseContextValidates(): void
     {
-        $context = new BecomingErrorContext(
+        $context = new BeingErrorCloseContext(
             error: 'RuntimeException',
             message: 'Something went wrong',
         );
 
         $contextData = json_decode(json_encode($context), false);
-        $this->validator->validate($contextData, $this->errorSchema, Constraint::CHECK_MODE_NORMAL);
+        $this->validator->validate($contextData, $this->errorCloseSchema, Constraint::CHECK_MODE_NORMAL);
 
         $this->assertTrue(
             $this->validator->isValid(),
-            'BecomingErrorContext should validate. Errors: ' . json_encode($this->validator->getErrors()),
+            'BeingErrorCloseContext should validate. Errors: ' . json_encode($this->validator->getErrors()),
         );
     }
 

--- a/tests/SemanticLog/JsonSchemaValidationTest.php
+++ b/tests/SemanticLog/JsonSchemaValidationTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Be\Framework\SemanticLog;
 
+use Be\Framework\SemanticLog\Context\BecomingCloseContext;
+use Be\Framework\SemanticLog\Context\BecomingOpenContext;
 use Be\Framework\SemanticLog\Context\BeingCloseContext;
 use Be\Framework\SemanticLog\Context\BeingErrorCloseContext;
 use Be\Framework\SemanticLog\Context\BeingFinalCloseContext;
@@ -27,6 +29,8 @@ use function json_encode;
 final class JsonSchemaValidationTest extends TestCase
 {
     private Validator $validator;
+    private object $becomingOpenSchema;
+    private object $becomingCloseSchema;
     private object $openSchema;
     private object $finalOpenSchema;
     private object $closeSchema;
@@ -37,11 +41,72 @@ final class JsonSchemaValidationTest extends TestCase
     {
         $this->validator = new Validator();
 
+        $this->becomingOpenSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/becoming-open.json'));
+        $this->becomingCloseSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/becoming-close.json'));
         $this->openSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/being-open.json'));
         $this->finalOpenSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/being-final-open.json'));
         $this->closeSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/being-close.json'));
         $this->finalCloseSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/being-final-close.json'));
         $this->errorCloseSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/being-error-close.json'));
+    }
+
+    public function testBecomingOpenContextValidatesAgainstSchema(): void
+    {
+        $context = new BecomingOpenContext(
+            input: 'Be\Framework\Test\UserInput',
+        );
+
+        $contextData = json_decode(json_encode($context), false);
+        $this->validator->validate($contextData, $this->becomingOpenSchema, Constraint::CHECK_MODE_NORMAL);
+
+        $this->assertTrue(
+            $this->validator->isValid(),
+            'BecomingOpenContext should validate. Errors: ' . json_encode($this->validator->getErrors()),
+        );
+    }
+
+    public function testBecomingCloseContextOnSuccessValidates(): void
+    {
+        $context = new BecomingCloseContext(
+            final: 'Be\Framework\Test\ActiveUser',
+        );
+
+        $contextData = json_decode(json_encode($context), false);
+        $this->validator->validate($contextData, $this->becomingCloseSchema, Constraint::CHECK_MODE_NORMAL);
+
+        $this->assertTrue(
+            $this->validator->isValid(),
+            'BecomingCloseContext (success) should validate. Errors: ' . json_encode($this->validator->getErrors()),
+        );
+    }
+
+    public function testBecomingCloseContextOnFailureValidates(): void
+    {
+        $context = new BecomingCloseContext(
+            error: 'RuntimeException',
+            message: 'chain failed',
+        );
+
+        $contextData = json_decode(json_encode($context), false);
+        $this->validator->validate($contextData, $this->becomingCloseSchema, Constraint::CHECK_MODE_NORMAL);
+
+        $this->assertTrue(
+            $this->validator->isValid(),
+            'BecomingCloseContext (failure) should validate. Errors: ' . json_encode($this->validator->getErrors()),
+        );
+    }
+
+    public function testBecomingCloseContextRejectsEmptyPayload(): void
+    {
+        // Empty or mixed success/error payloads must fail the oneOf constraint.
+        $empty = (object) [];
+
+        $this->validator->validate($empty, $this->becomingCloseSchema, Constraint::CHECK_MODE_NORMAL);
+
+        $this->assertFalse(
+            $this->validator->isValid(),
+            'Empty becoming_close payload should not validate.',
+        );
     }
 
     public function testBeingOpenContextValidatesAgainstSchema(): void

--- a/tests/SemanticLog/JsonSchemaValidationTest.php
+++ b/tests/SemanticLog/JsonSchemaValidationTest.php
@@ -138,7 +138,7 @@ final class JsonSchemaValidationTest extends TestCase
     {
         $context = new BeingFinalOpenContext(
             from: 'Be\Framework\Test\ProcessingData',
-            be: 'Be\Framework\Test\TerminalResult',
+            final: 'Be\Framework\Test\TerminalResult',
             input: ['data' => 'ProcessingData::data'],
             inject: [],
         );
@@ -190,11 +190,11 @@ final class JsonSchemaValidationTest extends TestCase
     public function testBeingFinalCloseContextValidates(): void
     {
         $context = new BeingFinalCloseContext(
+            final: 'Be\Framework\Test\FinalClass',
             prop: [
                 'result' => 'success',
                 'data' => ['key' => 'value'],
             ],
-            final: 'Be\Framework\Test\FinalClass',
         );
 
         $contextData = json_decode(json_encode($context), false);
@@ -203,6 +203,46 @@ final class JsonSchemaValidationTest extends TestCase
         $this->assertTrue(
             $this->validator->isValid(),
             'BeingFinalCloseContext should validate. Errors: ' . json_encode($this->validator->getErrors()),
+        );
+    }
+
+    public function testBeingFinalCloseContextOmitsBeenWhenEmpty(): void
+    {
+        $context = new BeingFinalCloseContext(
+            final: 'Be\Framework\Test\FinalClass',
+            prop: ['ok' => true],
+            been: [],
+        );
+
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode(json_encode($context), true);
+
+        $this->assertArrayNotHasKey(
+            'been',
+            $payload,
+            'Empty been must be omitted from the serialized payload.',
+        );
+    }
+
+    public function testBeingFinalCloseContextWithBeenValidates(): void
+    {
+        $event = new BeingFinalCloseContext(
+            final: 'Stub\\Event',
+            prop: ['marker' => true],
+        );
+
+        $context = new BeingFinalCloseContext(
+            final: 'Be\Framework\Test\FinalClass',
+            prop: ['result' => 'success'],
+            been: [$event],
+        );
+
+        $contextData = json_decode(json_encode($context), false);
+        $this->validator->validate($contextData, $this->finalCloseSchema, Constraint::CHECK_MODE_NORMAL);
+
+        $this->assertTrue(
+            $this->validator->isValid(),
+            'BeingFinalCloseContext with been should validate. Errors: ' . json_encode($this->validator->getErrors()),
         );
     }
 

--- a/tests/SemanticLog/LoggerErrorPathTest.php
+++ b/tests/SemanticLog/LoggerErrorPathTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Be\Framework\SemanticLog;
 
 use Be\Framework\BecomingArgumentsInterface;
-use Be\Framework\SemanticLog\Context\BecomingBeingContext;
-use Be\Framework\SemanticLog\Context\BecomingErrorContext;
-use Be\Framework\SemanticLog\Context\BecomingFinalContext;
-use Be\Framework\SemanticLog\Context\BecomingOpenContext;
+use Be\Framework\SemanticLog\Context\BeingCloseContext;
+use Be\Framework\SemanticLog\Context\BeingErrorCloseContext;
+use Be\Framework\SemanticLog\Context\BeingFinalCloseContext;
+use Be\Framework\SemanticLog\Context\BeingOpenContext;
+use Koriym\SemanticLogger\SemanticLogger;
 use Koriym\SemanticLogger\SemanticLoggerInterface;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
@@ -36,7 +37,7 @@ final class LoggerErrorPathTest extends TestCase
     {
         $input = new stdClass();
 
-        $openId = $this->logger->open($input, stdClass::class);
+        $openId = $this->logger->open($input, stdClass::class, []);
 
         $this->assertIsString($openId);
         $this->assertTrue(is_string($openId));
@@ -59,7 +60,7 @@ final class LoggerErrorPathTest extends TestCase
             public string $data = 'test';
         };
 
-        $openId = $this->logger->open($objectWithoutBeAttribute, stdClass::class);
+        $openId = $this->logger->open($objectWithoutBeAttribute, stdClass::class, []);
         $this->logger->close($objectWithoutBeAttribute, $openId);
 
         $this->expectNotToPerformAssertions();
@@ -75,7 +76,7 @@ final class LoggerErrorPathTest extends TestCase
             }
         };
 
-        $openId = $this->logger->open($complexObject, stdClass::class);
+        $openId = $this->logger->open($complexObject, stdClass::class, []);
         $this->logger->close($complexObject, $openId);
 
         $this->expectNotToPerformAssertions();
@@ -84,7 +85,7 @@ final class LoggerErrorPathTest extends TestCase
     public function testLoggerWithNullResult(): void
     {
         $input = new stdClass();
-        $openId = $this->logger->open($input, stdClass::class);
+        $openId = $this->logger->open($input, stdClass::class, []);
 
         // Close with null result (no exception) — legacy path, still closes
         $this->logger->close(null, $openId);
@@ -94,26 +95,26 @@ final class LoggerErrorPathTest extends TestCase
 
     public function testLoggerWithException(): void
     {
-        // Use a real SemanticLogger so we can inspect the emitted becoming_error payload.
-        $semanticLogger = new \Koriym\SemanticLogger\SemanticLogger();
+        // Use a real SemanticLogger so we can inspect the emitted being_error_close payload.
+        $semanticLogger = new SemanticLogger();
         $becomingArguments = $this->createMock(BecomingArgumentsInterface::class);
         $logger = new Logger($semanticLogger, $becomingArguments);
 
         $input = new stdClass();
-        $openId = $logger->open($input, stdClass::class);
+        $openId = $logger->open($input, stdClass::class, []);
 
         $logger->close(null, $openId, new RuntimeException('boom'));
 
         $logData = $semanticLogger->toArray();
-        $this->assertSame('becoming_error', $logData['close']['type']);
-        $this->assertSame(RuntimeException::class, $logData['close']['context']['error']);
-        $this->assertSame('boom', $logData['close']['context']['message']);
+        $this->assertSame('being_error_close', $logData['close'][0]['type']);
+        $this->assertSame(RuntimeException::class, $logData['close'][0]['context']['error']);
+        $this->assertSame('boom', $logData['close'][0]['context']['message']);
     }
 
     public function testLoggerContextsCreation(): void
     {
         $input = new stdClass();
-        $openId = $this->logger->open($input, stdClass::class);
+        $openId = $this->logger->open($input, stdClass::class, []);
 
         $result = new class {
             public string $output = 'result';
@@ -124,9 +125,9 @@ final class LoggerErrorPathTest extends TestCase
         $this->expectNotToPerformAssertions();
     }
 
-    public function testBecomingOpenContextCreation(): void
+    public function testBeingOpenContextCreation(): void
     {
-        $openContext = new BecomingOpenContext(
+        $openContext = new BeingOpenContext(
             from: 'TestSource',
             be: 'TestDestination',
             input: ['prop1' => 'value1'],
@@ -139,9 +140,9 @@ final class LoggerErrorPathTest extends TestCase
         $this->assertSame(['service' => 'injected'], $openContext->inject);
     }
 
-    public function testBecomingBeingContextCreation(): void
+    public function testBeingCloseContextCreation(): void
     {
-        $ctx = new BecomingBeingContext(
+        $ctx = new BeingCloseContext(
             prop: ['result' => 'success'],
             being: 'TargetClass',
         );
@@ -150,9 +151,9 @@ final class LoggerErrorPathTest extends TestCase
         $this->assertSame('TargetClass', $ctx->being);
     }
 
-    public function testBecomingFinalContextCreation(): void
+    public function testBeingFinalCloseContextCreation(): void
     {
-        $ctx = new BecomingFinalContext(
+        $ctx = new BeingFinalCloseContext(
             prop: ['value' => 42],
             final: 'TerminalClass',
         );
@@ -161,9 +162,9 @@ final class LoggerErrorPathTest extends TestCase
         $this->assertSame('TerminalClass', $ctx->final);
     }
 
-    public function testBecomingErrorContextCreation(): void
+    public function testBeingErrorCloseContextCreation(): void
     {
-        $ctx = new BecomingErrorContext(
+        $ctx = new BeingErrorCloseContext(
             error: 'RuntimeException',
             message: 'boom',
         );
@@ -182,7 +183,7 @@ final class LoggerErrorPathTest extends TestCase
             }
         };
 
-        $openId = $this->logger->open($injectorObject, stdClass::class);
+        $openId = $this->logger->open($injectorObject, stdClass::class, []);
         $this->logger->close($injectorObject, $openId);
 
         $this->expectNotToPerformAssertions();

--- a/tests/SemanticLog/LoggerTest.php
+++ b/tests/SemanticLog/LoggerTest.php
@@ -71,7 +71,7 @@ final class LoggerTest extends TestCase
         $openData = $logData['open'][0];
         assert(is_array($openData['context']));
         $this->assertEquals(TestInput::class, $openData['context']['from']);
-        $this->assertEquals(FakeProcessedData::class, $openData['context']['be']);
+        $this->assertEquals(FakeProcessedData::class, $openData['context']['final']);
         // FakeProcessedData has no #[Be] → terminal target → being_final_open
         $this->assertEquals('being_final_open', $openData['type']);
 
@@ -170,7 +170,6 @@ final class LoggerTest extends TestCase
     {
         $reflection = new ReflectionClass($this->logger);
         $method = $reflection->getMethod('extractTranscendentSources');
-        $method->setAccessible(true);
 
         $args = [
             'data' => 'test data',
@@ -221,7 +220,6 @@ final class LoggerTest extends TestCase
     {
         $reflection = new ReflectionClass($this->logger);
         $method = $reflection->getMethod('extractTranscendentSources');
-        $method->setAccessible(true);
 
         $args = ['data' => 'test'];
         $result = $method->invoke($this->logger, $args, NoConstructorClass::class);
@@ -233,7 +231,6 @@ final class LoggerTest extends TestCase
     {
         $reflection = new ReflectionClass($this->logger);
         $method = $reflection->getMethod('extractProperties');
-        $method->setAccessible(true);
 
         $testObject = new stdClass();
         $testObject->prop1 = 'value1';
@@ -252,7 +249,6 @@ final class LoggerTest extends TestCase
         // and must ignore public static properties entirely.
         $reflection = new ReflectionClass($this->logger);
         $method = $reflection->getMethod('extractProperties');
-        $method->setAccessible(true);
 
         $acceptLike = new class {
             public static string $shared = 'class-level';
@@ -272,7 +268,6 @@ final class LoggerTest extends TestCase
     {
         $reflection = new ReflectionClass($this->logger);
         $method = $reflection->getMethod('extractTranscendentSources');
-        $method->setAccessible(true);
 
         $injectedObject = new stdClass();
         $injectedObject->test = 'value';

--- a/tests/SemanticLog/LoggerTest.php
+++ b/tests/SemanticLog/LoggerTest.php
@@ -14,6 +14,7 @@ use Be\Framework\TestInputWithDependency;
 use Be\Framework\TestMultipleDestination;
 use Be\Framework\TestSingleDestination;
 use Koriym\SemanticLogger\SemanticLogger;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 use ReflectionClass;
@@ -142,6 +143,16 @@ final class LoggerTest extends TestCase
         // close() with empty openId returns early without error
         $this->logger->close(new stdClass(), '');
         $this->assertTrue(true);
+    }
+
+    public function testCloseChainRejectsNullFinalWithoutException(): void
+    {
+        // closeChain(null, $id) with no exception has no valid close-payload shape
+        // under the becoming-close oneOf schema — refuse rather than emit empty {}.
+        $chainId = $this->logger->openChain(new TestInput('data'));
+
+        $this->expectException(LogicException::class);
+        $this->logger->closeChain(null, $chainId);
     }
 
     public function testComplexTransformationWithDependency(): void

--- a/tests/SemanticLog/LoggerTest.php
+++ b/tests/SemanticLog/LoggerTest.php
@@ -55,7 +55,7 @@ final class LoggerTest extends TestCase
     {
         $input = new TestInput('test data');
 
-        $openId = $this->logger->open($input, FakeProcessedData::class);
+        $openId = $this->logger->open($input, FakeProcessedData::class, []);
         $this->assertNotEmpty($openId);
 
         $result = new stdClass();
@@ -65,52 +65,58 @@ final class LoggerTest extends TestCase
         $logData = $this->semanticLogger->toArray();
         $this->assertArrayHasKey('open', $logData);
         $this->assertArrayHasKey('close', $logData);
+        assert(is_array($logData['open']) && is_array($logData['close']));
 
         // Verify open log structure — short keys
-        $openData = $logData['open'];
-        assert(is_array($openData) && is_array($openData['context']));
+        $openData = $logData['open'][0];
+        assert(is_array($openData['context']));
         $this->assertEquals(TestInput::class, $openData['context']['from']);
         $this->assertEquals(FakeProcessedData::class, $openData['context']['be']);
+        // FakeProcessedData has no #[Be] → terminal target → being_final_open
+        $this->assertEquals('being_final_open', $openData['type']);
 
         // Verify close log structure — result has no further #[Be] so it's final.
-        $closeData = $logData['close'];
-        assert(is_array($closeData) && is_array($closeData['context']));
+        $closeData = $logData['close'][0];
+        assert(is_array($closeData['context']));
         $this->assertArrayHasKey('prop', $closeData['context']);
         $this->assertArrayHasKey('final', $closeData['context']);
     }
 
-    public function testArrayBecomingLogging(): void
+    public function testOpenWithIntermediateBeingTarget(): void
     {
+        // TestSingleDestination carries #[Be(FakeProcessedData::class)] — intermediate target
         $input = new TestInput('test data');
 
-        // Array becoming — be is pipe-joined
-        $openId = $this->logger->open($input, ['Class1', 'Class2']);
+        $openId = $this->logger->open($input, TestSingleDestination::class, []);
         $this->assertNotEmpty($openId);
 
         $this->logger->close(new stdClass(), $openId);
 
         $logData = $this->semanticLogger->toArray();
-        $openData = $logData['open'];
-        assert(is_array($openData) && is_array($openData['context']));
-        $this->assertEquals('Class1|Class2', $openData['context']['be']);
+        assert(is_array($logData['open']));
+        $openData = $logData['open'][0];
+        assert(is_array($openData['context']));
+        $this->assertEquals('being_open', $openData['type']);
+        $this->assertEquals(TestSingleDestination::class, $openData['context']['be']);
         // Empty maps are emitted as stdClass so the JSON form is "{}" rather than "[]".
-        $this->assertEquals(new \stdClass(), $openData['context']['input']);
-        $this->assertEquals(new \stdClass(), $openData['context']['inject']);
+        $this->assertEquals(new stdClass(), $openData['context']['input']);
+        $this->assertEquals(new stdClass(), $openData['context']['inject']);
     }
 
     public function testErrorLogging(): void
     {
         $input = new TestInput('test data');
 
-        $openId = $this->logger->open($input, FakeProcessedData::class);
+        $openId = $this->logger->open($input, FakeProcessedData::class, []);
 
         $exception = new RuntimeException('Test error message');
         $this->logger->close(null, $openId, $exception);
 
         $logData = $this->semanticLogger->toArray();
-        $closeData = $logData['close'];
+        assert(is_array($logData['close']));
+        $closeData = $logData['close'][0];
         assert(is_array($closeData) && is_array($closeData['context']));
-        $this->assertEquals('becoming_error', $closeData['type']);
+        $this->assertEquals('being_error_close', $closeData['type']);
         $this->assertEquals(RuntimeException::class, $closeData['context']['error']);
         $this->assertEquals('Test error message', $closeData['context']['message']);
     }
@@ -119,14 +125,15 @@ final class LoggerTest extends TestCase
     {
         $input = new TestInput('test data');
 
-        $openId = $this->logger->open($input, FakeProcessedData::class);
+        $openId = $this->logger->open($input, FakeProcessedData::class, []);
 
         // Null result without exception — still closes as error with 'Unknown error'
         $this->logger->close(null, $openId);
 
         $logData = $this->semanticLogger->toArray();
-        $closeData = $logData['close'];
-        $this->assertEquals('becoming_error', $closeData['type']);
+        assert(is_array($logData['close']));
+        $closeData = $logData['close'][0];
+        $this->assertEquals('being_error_close', $closeData['type']);
         $this->assertEquals('Unknown error', $closeData['context']['message']);
     }
 
@@ -142,19 +149,20 @@ final class LoggerTest extends TestCase
         $injector = new Injector();
         $input = new TestInputWithDependency('test data', $injector);
 
-        $openId = $this->logger->open($input, FakeProcessedData::class);
+        $openId = $this->logger->open($input, FakeProcessedData::class, []);
 
         // FakeProcessedData has no further #[Be] → final close
         $result = new FakeProcessedData('processed');
         $this->logger->close($result, $openId);
 
         $logData = $this->semanticLogger->toArray();
-        $openData = $logData['open'];
-        $closeData = $logData['close'];
+        assert(is_array($logData['open']) && is_array($logData['close']));
+        $openData = $logData['open'][0];
+        $closeData = $logData['close'][0];
 
         $this->assertArrayHasKey('inject', $openData['context']);
 
-        $this->assertEquals('becoming_final', $closeData['type']);
+        $this->assertEquals('being_final_close', $closeData['type']);
         $this->assertEquals(FakeProcessedData::class, $closeData['context']['final']);
     }
 
@@ -178,32 +186,34 @@ final class LoggerTest extends TestCase
     public function testMultipleDestination(): void
     {
         $input = new TestInput('test data');
-        $openId = $this->logger->open($input, FakeProcessedData::class);
+        $openId = $this->logger->open($input, FakeProcessedData::class, []);
 
         // TestMultipleDestination has #[Be([A, B])] — next step is "being" (continuing)
         $result = new TestMultipleDestination();
         $this->logger->close($result, $openId);
 
         $logData = $this->semanticLogger->toArray();
-        $closeData = $logData['close'];
+        assert(is_array($logData['close']));
+        $closeData = $logData['close'][0];
 
-        $this->assertEquals('becoming_being', $closeData['type']);
+        $this->assertEquals('being_close', $closeData['type']);
         $this->assertEquals(TestMultipleDestination::class, $closeData['context']['being']);
     }
 
     public function testSingleDestination(): void
     {
         $input = new TestInput('test data');
-        $openId = $this->logger->open($input, FakeProcessedData::class);
+        $openId = $this->logger->open($input, FakeProcessedData::class, []);
 
         // TestSingleDestination has #[Be(FakeProcessedData::class)] — next step is "being"
         $result = new TestSingleDestination('test');
         $this->logger->close($result, $openId);
 
         $logData = $this->semanticLogger->toArray();
-        $closeData = $logData['close'];
+        assert(is_array($logData['close']));
+        $closeData = $logData['close'][0];
 
-        $this->assertEquals('becoming_being', $closeData['type']);
+        $this->assertEquals('being_close', $closeData['type']);
         $this->assertEquals(TestSingleDestination::class, $closeData['context']['being']);
     }
 

--- a/tests/SemanticLog/SchemaComplianceTest.php
+++ b/tests/SemanticLog/SchemaComplianceTest.php
@@ -52,17 +52,20 @@ final class SchemaComplianceTest extends TestCase
     {
         $input = new TestInputForSchema('test data');
 
-        $openId = $this->logger->open($input, FakeProcessedData::class);
+        $openId = $this->logger->open($input, FakeProcessedData::class, ['data' => 'test data']);
         $this->assertNotEmpty($openId);
 
         $result = new FakeProcessedData('test data');
         $this->logger->close($result, $openId);
 
         $logData = $this->semanticLogger->toArray();
-        assert(is_array($logData['open']) && is_array($logData['open']['context']));
-        $openContext = $logData['open']['context'];
+        assert(is_array($logData['open']) && is_array($logData['open'][0]) && is_array($logData['open'][0]['context']));
+        $openContext = $logData['open'][0]['context'];
 
-        // Short keys — becoming-open schema
+        // FakeProcessedData has no #[Be] → terminal target → being_final_open
+        $this->assertEquals('being_final_open', $logData['open'][0]['type']);
+
+        // Short keys — being-final-open schema
         $this->assertArrayHasKey('from', $openContext);
         $this->assertArrayHasKey('be', $openContext);
         $this->assertArrayHasKey('input', $openContext);
@@ -83,18 +86,18 @@ final class SchemaComplianceTest extends TestCase
     public function testCloseContextSchemaCompliance(): void
     {
         $input = new TestInputForSchema('test data');
-        $openId = $this->logger->open($input, FakeProcessedData::class);
+        $openId = $this->logger->open($input, FakeProcessedData::class, ['data' => 'test data']);
 
         $result = new FakeProcessedData('test data');
         $this->logger->close($result, $openId);
 
         $logData = $this->semanticLogger->toArray();
-        assert(is_array($logData['close']) && is_array($logData['close']['context']));
-        $closeData = $logData['close'];
+        assert(is_array($logData['close']) && is_array($logData['close'][0]) && is_array($logData['close'][0]['context']));
+        $closeData = $logData['close'][0];
         $closeContext = $closeData['context'];
 
-        // FakeProcessedData has no further #[Be] → becoming_final
-        $this->assertEquals('becoming_final', $closeData['type']);
+        // FakeProcessedData has no further #[Be] → being_final_close
+        $this->assertEquals('being_final_close', $closeData['type']);
         $this->assertArrayHasKey('prop', $closeContext);
         $this->assertArrayHasKey('final', $closeContext);
         $this->assertEquals(FakeProcessedData::class, $closeContext['final']);
@@ -103,7 +106,7 @@ final class SchemaComplianceTest extends TestCase
     public function testJSONSchemaValidation(): void
     {
         $input = new TestInputForSchema('test data');
-        $openId = $this->logger->open($input, FakeProcessedData::class);
+        $openId = $this->logger->open($input, FakeProcessedData::class, ['data' => 'test data']);
 
         $result = new FakeProcessedData('test data');
         $this->logger->close($result, $openId);
@@ -112,21 +115,22 @@ final class SchemaComplianceTest extends TestCase
 
         $validator = new Validator();
 
-        $openSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/becoming-open.json'));
-        $openContext = json_decode(json_encode($logData['open']['context']));
+        // FakeProcessedData has no #[Be], so the open context is the being-final-open form.
+        $openSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/being-final-open.json'));
+        $openContext = json_decode(json_encode($logData['open'][0]['context']));
         $validator->validate($openContext, $openSchema, Constraint::CHECK_MODE_NORMAL);
         $this->assertTrue(
             $validator->isValid(),
-            'becoming_open context should validate. Errors: ' . json_encode($validator->getErrors()),
+            'being_final_open context should validate. Errors: ' . json_encode($validator->getErrors()),
         );
 
-        $finalSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/becoming-final.json'));
-        $closeContext = json_decode(json_encode($logData['close']['context']));
+        $finalSchema = json_decode(file_get_contents(__DIR__ . '/../../docs/schemas/being-final-close.json'));
+        $closeContext = json_decode(json_encode($logData['close'][0]['context']));
         $validator->reset();
         $validator->validate($closeContext, $finalSchema, Constraint::CHECK_MODE_NORMAL);
         $this->assertTrue(
             $validator->isValid(),
-            'becoming_final context should validate. Errors: ' . json_encode($validator->getErrors()),
+            'being_final_close context should validate. Errors: ' . json_encode($validator->getErrors()),
         );
     }
 }

--- a/tests/SemanticLog/SchemaComplianceTest.php
+++ b/tests/SemanticLog/SchemaComplianceTest.php
@@ -67,15 +67,15 @@ final class SchemaComplianceTest extends TestCase
 
         // Short keys — being-final-open schema
         $this->assertArrayHasKey('from', $openContext);
-        $this->assertArrayHasKey('be', $openContext);
+        $this->assertArrayHasKey('final', $openContext);
         $this->assertArrayHasKey('input', $openContext);
         $this->assertArrayHasKey('inject', $openContext);
 
         $this->assertIsString($openContext['from']);
-        $this->assertIsString($openContext['be']);
+        $this->assertIsString($openContext['final']);
 
         $this->assertEquals(TestInputForSchema::class, $openContext['from']);
-        $this->assertEquals(FakeProcessedData::class, $openContext['be']);
+        $this->assertEquals(FakeProcessedData::class, $openContext['final']);
         // jsonSerialize wraps assoc maps in stdClass so empty/nested values serialize as JSON objects.
         $this->assertEquals(
             (object) ['data' => 'Be\Framework\SemanticLog\TestInputForSchema::data'],

--- a/tests/SemanticVariable/SemanticValidatorEdgeCaseTest.php
+++ b/tests/SemanticVariable/SemanticValidatorEdgeCaseTest.php
@@ -116,7 +116,7 @@ final class SemanticValidatorEdgeCaseTest extends TestCase
             public function __construct(
                 public string $email,
                 public int $age,
-                public string $missing_prop,
+                public string $missingProp,
             ) {
             }
         };
@@ -195,7 +195,7 @@ final class SemanticValidatorEdgeCaseTest extends TestCase
     {
         // Test method matching logic to hit various uncovered branches
         $complexValidationClass = new class {
-            // Method with Inject attribute (should be skipped)
+            /** Method with Inject attribute (should be skipped) */
             public function validateWithInject(
                 string $value,
                 #[Inject]
@@ -204,7 +204,7 @@ final class SemanticValidatorEdgeCaseTest extends TestCase
                 return [];
             }
 
-            // Method with semantic tag attributes on parameters
+            /** Method with semantic tag attributes on parameters */
             public function validateWithSemanticTags(
                 #[Email]
                 string $email,
@@ -213,7 +213,7 @@ final class SemanticValidatorEdgeCaseTest extends TestCase
                 return empty($email) ? ['Email cannot be empty'] : [];
             }
 
-            // Method without attributes (should match non-attribute-specific)
+            /** Method without attributes (should match non-attribute-specific) */
             public function validateBasic(string $value): array
             {
                 return [];

--- a/tests/SemanticVariable/ValidationMessageHandlerTest.php
+++ b/tests/SemanticVariable/ValidationMessageHandlerTest.php
@@ -276,7 +276,7 @@ final class ValidationMessageHandlerTest extends TestCase
             /** @var resource */
             public readonly mixed $resourceValue;
 
-            public function __construct($resource)
+            public function __construct(mixed $resource)
             {
                 $this->resourceValue = $resource;
 


### PR DESCRIPTION
## Summary

Three related changes that together give the metamorphosis log tree a coherent ontology and an OpenTelemetry-compatible single root.

- **Outer chain span.** `openChain`/`closeChain` on `LoggerInterface` wrap the whole `Becoming` loop with `BecomingOpen`/`BecomingCloseContext`, so every step-level span shares a parent instead of emitting as a forest of disconnected opens.
- **Step contexts reshaped around being-state.** Replaced the old `BecomingBeing`/`Error`/`Final` close-only triple with five step-level contexts: `BeingOpen` / `BeingFinalOpen` picked at open time by the target's `#[Be]`; `BeingClose` / `BeingFinalClose` / `BeingErrorClose` picked at close time by the result's `#[Be]` or thrown exception. Bare *Being* is the continuing case, *Final* is terminal, *Error* only exists on the close side because an error is precisely an open-close that could not complete.
- **Args resolved before `logger->open` in `Being.php`.** If constructor argument resolution throws (`SemanticVariableException`, `UnbecomingException`, …) no span is opened for that candidate, removing the ghost span that used to appear for every rejected multi-candidate attempt. `Logger::open` now takes the pre-resolved args and the `string|array` union is gone — each candidate is its own single-class open/close pair.

Also: added `#[Override]` to `BeModule::configure` and removed the unused private `SemanticValidator::isSemanticTagClass` surfaced by psalm in passing.

## Test plan

- [x] `composer cs-fix` — no violations
- [x] `composer sa` — phpstan (level max) + psalm (errorLevel 1) both clean
- [x] `composer test` — 231/231 pass
- [x] Fixture `tests/Integration/Ldd/RegisterUser/been.json` re-validated against the new schemas
- [ ] Reviewer: inspect `docs/schemas/*.json` for the new shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chain-level semantic logging to correlate full transformation sequences.
  * New, clearer lifecycle event types for open/close/error/final steps and richer context payloads (including optional "been" history).
  * Logger now records resolved constructor arguments and prevents spurious spans when resolution fails.

* **Documentation**
  * Updated logging architecture and added/rewrote JSON schemas for the new lifecycle events.

* **Chores**
  * Bumped semantic-logger dependency to a newer minor version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->