### PR TITLE
Enrich chain logs with exit and input props

### DIFF
--- a/docs/schemas/becoming-close.json
+++ b/docs/schemas/becoming-close.json
@@ -2,11 +2,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://be-framework.org/schemas/becoming-close.json",
   "title": "Becoming Close Context",
-  "description": "Close context for the outer chain span. On success, carries the final being's FQCN; on failure, carries the exception that ended the chain.",
+  "description": "Close context for the outer chain span. Carries the chain exit state and either the final being's FQCN or the exception that ended the chain.",
   "type": "object",
   "oneOf": [
     {
-      "required": ["final"],
+      "required": ["exit", "final"],
+      "properties": {
+        "exit": { "const": "success" }
+      },
       "not": {
         "anyOf": [
           { "required": ["error"] },
@@ -15,11 +18,19 @@
       }
     },
     {
-      "required": ["error", "message"],
+      "required": ["exit", "error", "message"],
+      "properties": {
+        "exit": { "const": "error" }
+      },
       "not": { "required": ["final"] }
     }
   ],
   "properties": {
+    "exit": {
+      "type": "string",
+      "enum": ["success", "error"],
+      "description": "Terminal status of the metamorphosis chain."
+    },
     "final": {
       "type": "string",
       "description": "Fully-qualified class name of the terminal being reached when the chain succeeded."

--- a/docs/schemas/becoming-open.json
+++ b/docs/schemas/becoming-open.json
@@ -9,6 +9,11 @@
     "input": {
       "type": "string",
       "description": "Fully-qualified class name of the initial input being that starts the chain."
+    },
+    "prop": {
+      "type": "object",
+      "description": "Snapshot of the initial input being's public properties at chain entry.",
+      "additionalProperties": true
     }
   },
   "additionalProperties": false

--- a/src/SemanticLog/Context/BecomingCloseContext.php
+++ b/src/SemanticLog/Context/BecomingCloseContext.php
@@ -12,9 +12,8 @@ use Override;
  * Close context for the whole metamorphosis chain.
  *
  * Emitted when the chain terminates — either because it reached a being with
- * no further #[Be], or because a transformation threw. Carries the final FQCN
- * (or null when the chain failed before reaching a terminal being) and, when
- * relevant, the exception that ended the chain.
+ * no further #[Be], or because a transformation threw. Carries the chain exit
+ * state plus either the terminal FQCN or the exception that ended the chain.
  */
 final class BecomingCloseContext extends AbstractContext implements JsonSerializable
 {
@@ -22,13 +21,19 @@ final class BecomingCloseContext extends AbstractContext implements JsonSerializ
 
     public const string SCHEMA_URL = 'https://be-framework.org/schemas/becoming-close.json';
 
+    public const string EXIT_SUCCESS = 'success';
+
+    public const string EXIT_ERROR = 'error';
+
     /**
-     * @param class-string|null $final   FQCN of the terminal being, or null if the chain failed.
-     * @param string|null       $error   FQCN of the thrown exception, or null on success.
-     * @param string|null       $message Exception message, or null on success.
+     * @param class-string|null              $final   FQCN of the terminal being, or null if the chain failed.
+     * @param self::EXIT_SUCCESS|self::EXIT_ERROR|null $exit    Exit status for the chain.
+     * @param string|null                    $error   FQCN of the thrown exception, or null on success.
+     * @param string|null                    $message Exception message, or null on success.
      */
     public function __construct(
         public readonly string|null $final = null,
+        public readonly string|null $exit = null,
         public readonly string|null $error = null,
         public readonly string|null $message = null,
     ) {
@@ -39,6 +44,10 @@ final class BecomingCloseContext extends AbstractContext implements JsonSerializ
     public function jsonSerialize(): array
     {
         $payload = [];
+        if ($this->exit !== null) {
+            $payload['exit'] = $this->exit;
+        }
+
         if ($this->final !== null) {
             $payload['final'] = $this->final;
         }

--- a/src/SemanticLog/Context/BecomingCloseContext.php
+++ b/src/SemanticLog/Context/BecomingCloseContext.php
@@ -26,14 +26,14 @@ final class BecomingCloseContext extends AbstractContext implements JsonSerializ
     public const string EXIT_ERROR = 'error';
 
     /**
+     * @param string            $exit    Exit status for the chain (self::EXIT_SUCCESS|self::EXIT_ERROR).
      * @param class-string|null $final   FQCN of the terminal being, or null if the chain failed.
-     * @param string|null       $exit    Exit status for the chain.
      * @param string|null       $error   FQCN of the thrown exception, or null on success.
      * @param string|null       $message Exception message, or null on success.
      */
     public function __construct(
+        public readonly string $exit,
         public readonly string|null $final = null,
-        public readonly string|null $exit = null,
         public readonly string|null $error = null,
         public readonly string|null $message = null,
     ) {
@@ -43,10 +43,7 @@ final class BecomingCloseContext extends AbstractContext implements JsonSerializ
     #[Override]
     public function jsonSerialize(): array
     {
-        $payload = [];
-        if ($this->exit !== null) {
-            $payload['exit'] = $this->exit;
-        }
+        $payload = ['exit' => $this->exit];
 
         if ($this->final !== null) {
             $payload['final'] = $this->final;

--- a/src/SemanticLog/Context/BecomingCloseContext.php
+++ b/src/SemanticLog/Context/BecomingCloseContext.php
@@ -26,10 +26,10 @@ final class BecomingCloseContext extends AbstractContext implements JsonSerializ
     public const string EXIT_ERROR = 'error';
 
     /**
-     * @param class-string|null              $final   FQCN of the terminal being, or null if the chain failed.
-     * @param self::EXIT_SUCCESS|self::EXIT_ERROR|null $exit    Exit status for the chain.
-     * @param string|null                    $error   FQCN of the thrown exception, or null on success.
-     * @param string|null                    $message Exception message, or null on success.
+     * @param class-string|null $final   FQCN of the terminal being, or null if the chain failed.
+     * @param string|null       $exit    Exit status for the chain.
+     * @param string|null       $error   FQCN of the thrown exception, or null on success.
+     * @param string|null       $message Exception message, or null on success.
      */
     public function __construct(
         public readonly string|null $final = null,

--- a/src/SemanticLog/Context/BecomingOpenContext.php
+++ b/src/SemanticLog/Context/BecomingOpenContext.php
@@ -21,18 +21,28 @@ final class BecomingOpenContext extends AbstractContext implements JsonSerializa
 
     public const string SCHEMA_URL = 'https://be-framework.org/schemas/becoming-open.json';
 
-    /** @param class-string $input FQCN of the initial input being that starts the chain. */
+    /**
+     * @param class-string         $input FQCN of the initial input being that starts the chain.
+     * @param array<string, mixed> $prop  Public input properties captured at chain entry.
+     */
     public function __construct(
         public readonly string $input,
+        public readonly array $prop = [],
     ) {
     }
 
-    /** @return array{input: string} */
+    /** @return array{input: string, prop?: array<string, mixed>} */
     #[Override]
     public function jsonSerialize(): array
     {
-        return [
+        $payload = [
             'input' => $this->input,
         ];
+
+        if ($this->prop !== []) {
+            $payload['prop'] = $this->prop;
+        }
+
+        return $payload;
     }
 }

--- a/src/SemanticLog/Logger.php
+++ b/src/SemanticLog/Logger.php
@@ -67,6 +67,7 @@ final class Logger implements LoggerInterface
     {
         return $this->logger->open(new BecomingOpenContext(
             input: $input::class,
+            prop: $this->extractProperties($input),
         ));
     }
 
@@ -87,6 +88,7 @@ final class Logger implements LoggerInterface
 
         if ($exception !== null) {
             $this->logger->close(new BecomingCloseContext(
+                exit: BecomingCloseContext::EXIT_ERROR,
                 error: $exception::class,
                 message: $exception->getMessage(),
             ), $openId);
@@ -101,6 +103,7 @@ final class Logger implements LoggerInterface
         }
 
         $this->logger->close(new BecomingCloseContext(
+            exit: BecomingCloseContext::EXIT_SUCCESS,
             final: $final::class,
         ), $openId);
     }

--- a/src/SemanticLog/Logger.php
+++ b/src/SemanticLog/Logger.php
@@ -25,7 +25,6 @@ use Ray\InputQuery\Attribute\Input;
 use ReflectionClass;
 use Throwable;
 
-use function array_filter;
 use function array_key_exists;
 use function get_debug_type;
 use function get_object_vars;
@@ -51,12 +50,14 @@ use const JSON_UNESCAPED_UNICODE;
 final class Logger implements LoggerInterface
 {
     private Being $being;
+    private ObjectPropertyExtractor $propertyExtractor;
 
     public function __construct(
         private SemanticLoggerInterface $logger,
         private BecomingArgumentsInterface $becomingArguments,
     ) {
         $this->being = new Being($this, $this->becomingArguments, new BecomingType());
+        $this->propertyExtractor = new ObjectPropertyExtractor();
     }
 
     /**
@@ -333,49 +334,11 @@ final class Logger implements LoggerInterface
      * and dynamic properties (stdClass, objects with __set).
      *
      * @return ObjectProperties
-     * @phpstan-return array<array-key, mixed>
+     * @phpstan-return array<string, mixed>
      */
     private function extractProperties(object $result): array
     {
-        // Exclude any `Been` property: it carries this very log and would
-        // embed the event stream recursively inside the close context.
-        // Start with dynamic properties (stdClass, objects with __set) which
-        // already come back with string keys via get_object_vars().
-        $properties = array_filter(
-            get_object_vars($result),
-            static fn (mixed $value): bool => ! ($value instanceof Been),
-        );
-
-        // Override/supplement with declared properties via reflection so
-        // Accept-pattern objects with uninitialized properties are included.
-        foreach ((new ReflectionClass($result))->getProperties() as $property) {
-            if (! $property->isPublic() || $property->isStatic()) {
-                continue;
-            }
-
-            $name = $property->getName();
-
-            // Handle uninitialized properties (Accept pattern objects may have these)
-            if (! $property->isInitialized($result)) {
-                $properties[$name] = null;
-                continue;
-            }
-
-            /**
-             * @psalm-suppress MixedAssignment
-             * @var mixed $value
-             */
-            $value = $property->getValue($result);
-            if ($value instanceof Been) {
-                unset($properties[$name]);
-                continue;
-            }
-
-            /** @psalm-suppress MixedAssignment */
-            $properties[$name] = $value;
-        }
-
-        return $properties;
+        return $this->propertyExtractor->extract($result);
     }
 
     /**

--- a/src/SemanticLog/ObjectPropertyExtractor.php
+++ b/src/SemanticLog/ObjectPropertyExtractor.php
@@ -26,14 +26,14 @@ final class ObjectPropertyExtractor
      */
     public function extract(object $result): array
     {
-        $properties = $this->dynamicProperties($result);
+        $properties = $this->collectVisibleProperties($result);
         $this->mergeDeclaredProperties($properties, $result);
 
         return $properties;
     }
 
     /** @return array<string, mixed> */
-    private function dynamicProperties(object $result): array
+    private function collectVisibleProperties(object $result): array
     {
         $properties = [];
         $dynamicProperties = get_object_vars($result);

--- a/src/SemanticLog/ObjectPropertyExtractor.php
+++ b/src/SemanticLog/ObjectPropertyExtractor.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\SemanticLog;
+
+use ReflectionClass;
+
+use function array_walk;
+use function get_object_vars;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_object;
+use function is_string;
+
+/**
+ * Safely extracts public object properties for semantic log payloads.
+ */
+final class ObjectPropertyExtractor
+{
+    /**
+     * @return ObjectProperties
+     * @phpstan-return array<string, mixed>
+     */
+    public function extract(object $result): array
+    {
+        $properties = $this->dynamicProperties($result);
+        $this->mergeDeclaredProperties($properties, $result);
+
+        return $properties;
+    }
+
+    /** @return array<string, mixed> */
+    private function dynamicProperties(object $result): array
+    {
+        $properties = [];
+        $dynamicProperties = get_object_vars($result);
+        array_walk(
+            $dynamicProperties,
+            static function (mixed $value, string $name) use (&$properties): void {
+                if ($value instanceof Been || ! self::isStorableValue($value)) {
+                    return;
+                }
+
+                self::storeProperty($properties, $name, $value);
+            },
+        );
+
+        return $properties;
+    }
+
+    /** @param array<string, mixed> $properties */
+    private function mergeDeclaredProperties(array &$properties, object $result): void
+    {
+        foreach ((new ReflectionClass($result))->getProperties() as $property) {
+            if (! $property->isPublic() || $property->isStatic()) {
+                continue;
+            }
+
+            $name = $property->getName();
+            if (! $property->isInitialized($result)) {
+                $properties[$name] = null;
+
+                continue;
+            }
+
+            /** @psalm-suppress MixedAssignment */
+            $value = $property->getValue($result);
+            if ($value instanceof Been) {
+                unset($properties[$name]);
+
+                continue;
+            }
+
+            if (! self::isStorableValue($value)) {
+                continue;
+            }
+
+            self::storeProperty($properties, $name, $value);
+        }
+    }
+
+    /** @psalm-assert-if-true array<array-key, mixed>|bool|float|int|object|string|null $value */
+    private static function isStorableValue(mixed $value): bool
+    {
+        return $value === null
+            || is_array($value)
+            || is_bool($value)
+            || is_float($value)
+            || is_int($value)
+            || is_object($value)
+            || is_string($value);
+    }
+
+    /**
+     * @param array<string, mixed>                                      $properties
+     * @param array<array-key, mixed>|bool|float|int|object|string|null $value
+     */
+    private static function storeProperty(array &$properties, string $name, array|bool|float|int|object|string|null $value): void
+    {
+        $properties[$name] = $value;
+    }
+}

--- a/tests/Integration/Ldd/RegisterUser/been.json
+++ b/tests/Integration/Ldd/RegisterUser/been.json
@@ -6,7 +6,10 @@
             "type": "becoming_open",
             "schemaUrl": "https://be-framework.org/schemas/becoming-open.json",
             "context": {
-                "input": "MyVendor\\MyApp\\Ldd\\RegisterUser\\UnverifiedEmail"
+                "input": "MyVendor\\MyApp\\Ldd\\RegisterUser\\UnverifiedEmail",
+                "prop": {
+                    "value": "alice@example.com"
+                }
             },
             "open": [
                 {
@@ -56,6 +59,7 @@
             "type": "becoming_close",
             "schemaUrl": "https://be-framework.org/schemas/becoming-close.json",
             "context": {
+                "exit": "success",
                 "final": "MyVendor\\MyApp\\Ldd\\RegisterUser\\RegisteredUser"
             },
             "openId": "becoming_open_1",

--- a/tests/SemanticLog/JsonSchemaValidationTest.php
+++ b/tests/SemanticLog/JsonSchemaValidationTest.php
@@ -54,6 +54,7 @@ final class JsonSchemaValidationTest extends TestCase
     {
         $context = new BecomingOpenContext(
             input: 'Be\Framework\Test\UserInput',
+            prop: ['email' => 'alice@example.com'],
         );
 
         $contextData = json_decode(json_encode($context), false);
@@ -68,6 +69,7 @@ final class JsonSchemaValidationTest extends TestCase
     public function testBecomingCloseContextOnSuccessValidates(): void
     {
         $context = new BecomingCloseContext(
+            exit: BecomingCloseContext::EXIT_SUCCESS,
             final: 'Be\Framework\Test\ActiveUser',
         );
 
@@ -83,6 +85,7 @@ final class JsonSchemaValidationTest extends TestCase
     public function testBecomingCloseContextOnFailureValidates(): void
     {
         $context = new BecomingCloseContext(
+            exit: BecomingCloseContext::EXIT_ERROR,
             error: 'RuntimeException',
             message: 'chain failed',
         );

--- a/tests/SemanticLog/LoggerTest.php
+++ b/tests/SemanticLog/LoggerTest.php
@@ -155,6 +155,54 @@ final class LoggerTest extends TestCase
         $this->logger->closeChain(null, $chainId);
     }
 
+    public function testOpenChainLogsInputProps(): void
+    {
+        $chainId = $this->logger->openChain(new TestInput('data'));
+        $this->logger->closeChain(new FakeProcessedData('done'), $chainId);
+
+        $this->assertNotSame('', $chainId);
+
+        $logData = $this->semanticLogger->toArray();
+        assert(is_array($logData['open']));
+        $openData = $logData['open'][0];
+        assert(is_array($openData) && is_array($openData['context']));
+
+        $this->assertSame('becoming_open', $openData['type']);
+        $this->assertSame(TestInput::class, $openData['context']['input']);
+        $this->assertSame(['data' => 'data'], $openData['context']['prop']);
+    }
+
+    public function testCloseChainLogsSuccessExit(): void
+    {
+        $chainId = $this->logger->openChain(new TestInput('data'));
+        $this->logger->closeChain(new FakeProcessedData('done'), $chainId);
+
+        $logData = $this->semanticLogger->toArray();
+        assert(is_array($logData['close']));
+        $closeData = $logData['close'][0];
+        assert(is_array($closeData) && is_array($closeData['context']));
+
+        $this->assertSame('becoming_close', $closeData['type']);
+        $this->assertSame('success', $closeData['context']['exit']);
+        $this->assertSame(FakeProcessedData::class, $closeData['context']['final']);
+    }
+
+    public function testCloseChainLogsErrorExit(): void
+    {
+        $chainId = $this->logger->openChain(new TestInput('data'));
+        $this->logger->closeChain(null, $chainId, new RuntimeException('chain failed'));
+
+        $logData = $this->semanticLogger->toArray();
+        assert(is_array($logData['close']));
+        $closeData = $logData['close'][0];
+        assert(is_array($closeData) && is_array($closeData['context']));
+
+        $this->assertSame('becoming_close', $closeData['type']);
+        $this->assertSame('error', $closeData['context']['exit']);
+        $this->assertSame(RuntimeException::class, $closeData['context']['error']);
+        $this->assertSame('chain failed', $closeData['context']['message']);
+    }
+
     public function testComplexTransformationWithDependency(): void
     {
         $injector = new Injector();


### PR DESCRIPTION
## What changed
- add `exit=success|error` to `becoming_close` context
- include initial input object props in `becoming_open` context
- extract object property collection into `ObjectPropertyExtractor` to keep `Logger` simpler
- update semantic log schemas and fixtures for the new context fields

## Why
`stree` needed cleaner semantic signals for chain start and end. The previous logs did not show initial input values at chain open, and `becoming_close` did not distinguish successful completion from error completion.

## Impact
- semantic log consumers can show input values at the chain root
- tree rendering can summarize chain completion with `exit=success|error`
- logger internals are simpler and easier to validate in static analysis

## Validation
- `composer tests`
- local end-to-end check from `skeleton` using the updated semantic log output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chain events now include an explicit exit status (success or error).
  * Public input properties are captured and attached to chain-entry events.

* **Documentation**
  * JSON schemas updated to require/validate the exit status and optional entry properties.

* **Tests**
  * Added/updated tests to validate logging of entry properties and explicit success/error exit states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->