### PR TITLE
Address review feedback on PR #71 error-handling changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,5 @@ Desktop.ini
 .nfs*
 /vendor/
 /.phpunit.result.cache
+/.phpcs-cache
 /composer.lock

--- a/src/BecomingType.php
+++ b/src/BecomingType.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Be\Framework;
 
-use LogicException;
 use Ray\Di\Di\Inject;
 use ReflectionClass;
 use ReflectionIntersectionType;
@@ -14,11 +13,11 @@ use ReflectionUnionType;
 
 use function array_key_exists;
 use function array_map;
+use function assert;
 use function get_object_vars;
 use function gettype;
 use function implode;
 use function is_object;
-use function sprintf;
 
 /**
  * Type compatibility and resolution utilities for the Becoming framework
@@ -134,10 +133,7 @@ final class BecomingType
             return implode('|', $types);
         }
 
-        if (! $type instanceof ReflectionIntersectionType) {
-            throw new LogicException(sprintf('Unknown ReflectionType: %s', $type::class));
-        }
-
+        assert($type instanceof ReflectionIntersectionType, 'Unknown ReflectionType encountered');
         $types = array_map(fn (ReflectionType $t) => $this->getTypeDescription($t), $type->getTypes());
 
         return implode('&', $types);
@@ -172,9 +168,7 @@ final class BecomingType
             return $this->handleUnionType($value, $type);
         }
 
-        if (! $type instanceof ReflectionIntersectionType) {
-            throw new LogicException(sprintf('Unknown ReflectionType: %s', $type::class));
-        }
+        assert($type instanceof ReflectionIntersectionType, 'Unknown ReflectionType encountered');
 
         return $this->handleIntersectionType($value, $type);
     }

--- a/src/BecomingType.php
+++ b/src/BecomingType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Be\Framework;
 
+use LogicException;
 use Ray\Di\Di\Inject;
 use ReflectionClass;
 use ReflectionIntersectionType;
@@ -17,6 +18,7 @@ use function get_object_vars;
 use function gettype;
 use function implode;
 use function is_object;
+use function sprintf;
 
 /**
  * Type compatibility and resolution utilities for the Becoming framework
@@ -133,7 +135,7 @@ final class BecomingType
         }
 
         if (! $type instanceof ReflectionIntersectionType) {
-            return 'unknown';
+            throw new LogicException(sprintf('Unknown ReflectionType: %s', $type::class));
         }
 
         $types = array_map(fn (ReflectionType $t) => $this->getTypeDescription($t), $type->getTypes());
@@ -171,7 +173,7 @@ final class BecomingType
         }
 
         if (! $type instanceof ReflectionIntersectionType) {
-            return false;
+            throw new LogicException(sprintf('Unknown ReflectionType: %s', $type::class));
         }
 
         return $this->handleIntersectionType($value, $type);

--- a/src/Exception/Unmatch.php
+++ b/src/Exception/Unmatch.php
@@ -46,7 +46,7 @@ final readonly class Unmatch
         }
 
         if ($this->details instanceof Throwable) {
-            return $this->details->getMessage();
+            return sprintf('%s: %s', $this->details::class, $this->details->getMessage());
         }
 
         if (is_object($this->details) && method_exists($this->details, '__toString')) {

--- a/src/SemanticLog/Logger.php
+++ b/src/SemanticLog/Logger.php
@@ -142,7 +142,7 @@ final class Logger implements LoggerInterface
     /**
      * Log transformation completion
      *
-     * @throws LogicException When result is null without an exception (programming error)
+     * @throws LogicException When result is null without an exception (programming error).
      */
     #[Override]
     public function close(object|null $result, string $openId, Throwable|null $exception = null): void

--- a/tests/SemanticLog/LoggerErrorPathTest.php
+++ b/tests/SemanticLog/LoggerErrorPathTest.php
@@ -11,6 +11,7 @@ use Be\Framework\SemanticLog\Context\BeingFinalCloseContext;
 use Be\Framework\SemanticLog\Context\BeingOpenContext;
 use Koriym\SemanticLogger\SemanticLogger;
 use Koriym\SemanticLogger\SemanticLoggerInterface;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\Injector;
 use RuntimeException;
@@ -84,15 +85,20 @@ final class LoggerErrorPathTest extends TestCase
         $this->expectNotToPerformAssertions();
     }
 
-    public function testLoggerWithNullResult(): void
+    public function testLoggerWithNullResultThrowsLogicException(): void
     {
+        // Use a real SemanticLogger so open() returns a non-empty id and close() reaches the null-result branch.
+        $semanticLogger = new SemanticLogger();
+        $becomingArguments = $this->createMock(BecomingArgumentsInterface::class);
+        $logger = new Logger($semanticLogger, $becomingArguments);
+
         $input = new stdClass();
-        $openId = $this->logger->open($input, stdClass::class, []);
+        $openId = $logger->open($input, stdClass::class, []);
 
-        // Close with null result (no exception) — legacy path, still closes
-        $this->logger->close(null, $openId);
-
-        $this->expectNotToPerformAssertions();
+        // Null result without exception is a programming error
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Logger::close() requires a result object on success');
+        $logger->close(null, $openId);
     }
 
     public function testLoggerWithException(): void


### PR DESCRIPTION
## Summary

Follow-up fixes to PR #71 addressing the issues raised in code review.

### Blocker fixed

- **`tests/SemanticLog/LoggerErrorPathTest.php`**: `testLoggerWithNullResult` was still asserting the old "silent close on null result" behavior that PR #71 replaced with a thrown `LogicException`. The test now expects the exception and uses a real `SemanticLogger` (matching the sibling `testLoggerWithException`), since the mock returned an empty `openId` that short-circuited `Logger::close()` before the throw could happen.

### Consistency / quality

- **`src/BecomingType.php`**: The PR replaced two `assert()` calls with silent `'unknown'`/`false` fallbacks. That contradicts the PR's own stated philosophy ("make programming errors explicit rather than hide them") that motivated the Logger change. Both now throw `LogicException` with the offending `ReflectionType` subclass name, which is what `assert()` was trying to signal anyway.
- **`src/Exception/Unmatch.php`**: For `Throwable` details, include the exception class alongside the message — `TypeError: Argument #1 must be string` is more actionable than a bare `Argument #1 must be string`.
- **`src/SemanticLog/Logger.php`**: The `@throws LogicException` line added in PR #71's fixup commit was missing the trailing full stop required by `Squiz.Commenting.FunctionComment.ThrowsNoFullStop`. Added it so `composer cs` is clean.

### Already addressed by PR #71's fixup commit (not in this PR)

- `@throws LogicException` on `Logger::close()` docblock.
- `@deprecated` annotation on `SemanticValidator::validate()`.

## Verification

- `composer cs` — clean.
- `composer sa` (phpstan + psalm) — no errors.
- `composer test` — 241 tests pass.

## Test plan

- [x] `composer cs` passes
- [x] `composer sa` passes
- [x] `composer test` passes
- [ ] Decide whether to merge this into PR #71's branch or land it independently after #71 merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEoU3qH5nFrKW2UKpHCii5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error exception messages now include the throwable class name for improved clarity and debugging.

* **Documentation**
  * Updated PHPDoc descriptions for consistency.

* **Chores**
  * Added PHPCS cache files to ignore list.

* **Tests**
  * Added test coverage for exception handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/be-framework/Be.Framework/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->