### PR TITLE
Add Psalm plugin to detect Being and Validate errors statically (#60)

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -10,8 +10,14 @@
         <directory name="src" />
         <ignoreFiles>
             <directory name="vendor" />
+            <!-- Plugin source itself: avoid meta-circular self-analysis -->
+            <directory name="src/Psalm" />
         </ignoreFiles>
     </projectFiles>
+
+    <plugins>
+        <pluginClass class="Be\Framework\Psalm\Plugin" />
+    </plugins>
 
     <issueHandlers>
         <!-- Framework API elements that appear unused but are actually necessary -->

--- a/src/Psalm/Handler/BeingParameterAttributeHandler.php
+++ b/src/Psalm/Handler/BeingParameterAttributeHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Be\Framework\Psalm\Handler;
 
 use Be\Framework\Psalm\Internal\AttributeNodeUtil;
+use Be\Framework\Psalm\Issue\ConflictingBeingParameterAttribute;
 use Be\Framework\Psalm\Issue\MissingBeingParameterAttribute;
 use PhpParser\Node;
 use Psalm\Aliases;
@@ -18,13 +19,12 @@ use function is_string;
 use function sprintf;
 
 /**
- * Detects Being constructor parameters missing #[Input] / #[Inject] attributes
+ * Detects invalid Being constructor parameter attributes
  *
  * Heuristic: a class is treated as a Being class if its constructor declares at
  * least one parameter annotated with #[Ray\InputQuery\Attribute\Input]. For such
- * classes, every constructor parameter must have either #[Input] or
- * #[Ray\Di\Di\Inject], otherwise {@see \Be\Framework\Exception\MissingParameterAttribute}
- * will be thrown at runtime by BecomingArguments.
+ * classes, every constructor parameter must have exactly one of #[Input] or
+ * #[Ray\Di\Di\Inject], otherwise BecomingArguments will throw at runtime.
  *
  * Skipped:
  *  - interfaces, traits, enums
@@ -48,8 +48,10 @@ final class BeingParameterAttributeHandler implements AfterClassLikeVisitInterfa
         $aliases = $source->getAliases();
         $className = (string) $event->getStorage()->name;
 
+        $suppressedIssues = $event->getStorage()->suppressed_issues;
+
         foreach ($ctor->params as $param) {
-            self::checkParam($param, $className, $source, $aliases);
+            self::checkParam($param, $className, $source, $aliases, $suppressedIssues);
         }
     }
 
@@ -90,19 +92,39 @@ final class BeingParameterAttributeHandler implements AfterClassLikeVisitInterfa
         return false;
     }
 
-    private static function checkParam(Node\Param $param, string $className, FileSource $source, Aliases $aliases): void
-    {
-        if (AttributeNodeUtil::hasAttribute($param->attrGroups, self::INPUT_FQCN, $aliases)) {
-            return;
-        }
-
-        if (AttributeNodeUtil::hasAttribute($param->attrGroups, self::INJECT_FQCN, $aliases)) {
-            return;
-        }
-
+    /** @param array<array-key, string> $suppressedIssues */
+    private static function checkParam(
+        Node\Param $param,
+        string $className,
+        FileSource $source,
+        Aliases $aliases,
+        array $suppressedIssues,
+    ): void {
+        $hasInput = AttributeNodeUtil::hasAttribute($param->attrGroups, self::INPUT_FQCN, $aliases);
+        $hasInject = AttributeNodeUtil::hasAttribute($param->attrGroups, self::INJECT_FQCN, $aliases);
         $paramName = $param->var instanceof Node\Expr\Variable && is_string($param->var->name)
             ? $param->var->name
             : 'unknown';
+
+        if ($hasInput && $hasInject) {
+            IssueBuffer::maybeAdd(
+                new ConflictingBeingParameterAttribute(
+                    sprintf(
+                        'Constructor parameter $%s of Being class %s has both #[Input] and #[Inject] attributes',
+                        $paramName,
+                        $className,
+                    ),
+                    new CodeLocation($source, $param),
+                ),
+                $suppressedIssues,
+            );
+
+            return;
+        }
+
+        if ($hasInput || $hasInject) {
+            return;
+        }
 
         IssueBuffer::maybeAdd(
             new MissingBeingParameterAttribute(
@@ -113,6 +135,7 @@ final class BeingParameterAttributeHandler implements AfterClassLikeVisitInterfa
                 ),
                 new CodeLocation($source, $param),
             ),
+            $suppressedIssues,
         );
     }
 }

--- a/src/Psalm/Handler/BeingParameterAttributeHandler.php
+++ b/src/Psalm/Handler/BeingParameterAttributeHandler.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Psalm\Handler;
+
+use Be\Framework\Psalm\Internal\AttributeNodeUtil;
+use Be\Framework\Psalm\Issue\MissingBeingParameterAttribute;
+use PhpParser\Node;
+use Psalm\Aliases;
+use Psalm\CodeLocation;
+use Psalm\FileSource;
+use Psalm\IssueBuffer;
+use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
+use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
+
+use function is_string;
+use function sprintf;
+
+/**
+ * Detects Being constructor parameters missing #[Input] / #[Inject] attributes
+ *
+ * Heuristic: a class is treated as a Being class if its constructor declares at
+ * least one parameter annotated with #[Ray\InputQuery\Attribute\Input]. For such
+ * classes, every constructor parameter must have either #[Input] or
+ * #[Ray\Di\Di\Inject], otherwise {@see \Be\Framework\Exception\MissingParameterAttribute}
+ * will be thrown at runtime by BecomingArguments.
+ *
+ * Skipped:
+ *  - interfaces, traits, enums
+ *  - abstract classes (cannot be instantiated as #[Be] target)
+ *  - classes whose constructor has no #[Input] params (not a Being)
+ */
+final class BeingParameterAttributeHandler implements AfterClassLikeVisitInterface
+{
+    private const string INPUT_FQCN = 'Ray\\InputQuery\\Attribute\\Input';
+    private const string INJECT_FQCN = 'Ray\\Di\\Di\\Inject';
+
+    public static function afterClassLikeVisit(AfterClassLikeVisitEvent $event): void
+    {
+        $ctor = self::resolveBeingConstructor($event);
+
+        if ($ctor === null) {
+            return;
+        }
+
+        $source = $event->getStatementsSource();
+        $aliases = $source->getAliases();
+        $className = (string) $event->getStorage()->name;
+
+        foreach ($ctor->params as $param) {
+            self::checkParam($param, $className, $source, $aliases);
+        }
+    }
+
+    /**
+     * Returns the constructor of a Being class, or null when this class isn't one
+     */
+    private static function resolveBeingConstructor(AfterClassLikeVisitEvent $event): Node\Stmt\ClassMethod|null
+    {
+        $class = $event->getStmt();
+
+        if (! $class instanceof Node\Stmt\Class_ || $class->isAbstract()) {
+            return null;
+        }
+
+        $ctor = AttributeNodeUtil::findConstructor($class);
+
+        if ($ctor === null || $ctor->params === []) {
+            return null;
+        }
+
+        $aliases = $event->getStatementsSource()->getAliases();
+
+        if (! self::hasAnyInputParameter($ctor, $aliases)) {
+            return null;
+        }
+
+        return $ctor;
+    }
+
+    private static function hasAnyInputParameter(Node\Stmt\ClassMethod $ctor, Aliases $aliases): bool
+    {
+        foreach ($ctor->params as $param) {
+            if (AttributeNodeUtil::hasAttribute($param->attrGroups, self::INPUT_FQCN, $aliases)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function checkParam(Node\Param $param, string $className, FileSource $source, Aliases $aliases): void
+    {
+        if (AttributeNodeUtil::hasAttribute($param->attrGroups, self::INPUT_FQCN, $aliases)) {
+            return;
+        }
+
+        if (AttributeNodeUtil::hasAttribute($param->attrGroups, self::INJECT_FQCN, $aliases)) {
+            return;
+        }
+
+        $paramName = $param->var instanceof Node\Expr\Variable && is_string($param->var->name)
+            ? $param->var->name
+            : 'unknown';
+
+        IssueBuffer::maybeAdd(
+            new MissingBeingParameterAttribute(
+                sprintf(
+                    'Constructor parameter $%s of Being class %s is missing #[Input] or #[Inject] attribute',
+                    $paramName,
+                    $className,
+                ),
+                new CodeLocation($source, $param),
+            ),
+        );
+    }
+}

--- a/src/Psalm/Handler/ValidateThrowHandler.php
+++ b/src/Psalm/Handler/ValidateThrowHandler.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Psalm\Handler;
+
+use Be\Framework\Psalm\Internal\AttributeNodeUtil;
+use Be\Framework\Psalm\Internal\ThrowCollectorVisitor;
+use Be\Framework\Psalm\Issue\InvalidValidateException;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use Psalm\Aliases;
+use Psalm\Codebase;
+use Psalm\CodeLocation;
+use Psalm\IssueBuffer;
+use Psalm\NodeTypeProvider;
+use Psalm\Plugin\EventHandler\AfterFunctionLikeAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterFunctionLikeAnalysisEvent;
+use Psalm\StatementsSource;
+use Psalm\Type\Atomic\TNamedObject;
+
+use function ltrim;
+use function sprintf;
+
+/**
+ * Detects #[Validate] methods that throw exceptions not extending DomainException
+ *
+ * The framework's SemanticValidator only catches DomainException; throws of any
+ * other type silently propagate, bypassing validation entirely. This handler
+ * walks the body of #[Validate]-annotated methods, collects throw statements,
+ * resolves their exception types via Psalm's NodeTypeProvider, and reports any
+ * type that does not extend \DomainException.
+ */
+final class ValidateThrowHandler implements AfterFunctionLikeAnalysisInterface
+{
+    private const string VALIDATE_FQCN = 'Be\\Framework\\Attribute\\Validate';
+    private const string DOMAIN_EXCEPTION = 'DomainException';
+
+    public static function afterStatementAnalysis(AfterFunctionLikeAnalysisEvent $event): bool|null
+    {
+        $stmt = $event->getStmt();
+
+        if (! $stmt instanceof Node\Stmt\ClassMethod) {
+            return null;
+        }
+
+        $source = $event->getStatementsSource();
+        $aliases = $source->getAliases();
+
+        if (! AttributeNodeUtil::hasAttribute($stmt->attrGroups, self::VALIDATE_FQCN, $aliases)) {
+            return null;
+        }
+
+        if ($stmt->stmts === null) {
+            return null;
+        }
+
+        $visitor = new ThrowCollectorVisitor();
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+        $traverser->traverse($stmt->stmts);
+
+        if ($visitor->throws === []) {
+            return null;
+        }
+
+        $codebase = $event->getCodebase();
+        $ntp = $event->getNodeTypeProvider();
+        $methodName = sprintf(
+            '%s::%s',
+            $source->getFQCLN() ?? 'unknown',
+            $stmt->name->toString(),
+        );
+
+        foreach ($visitor->throws as $throw) {
+            self::checkThrow($throw, $methodName, $source, $codebase, $ntp, $aliases);
+        }
+
+        return null;
+    }
+
+    private static function checkThrow(
+        Node\Expr\Throw_ $throw,
+        string $methodName,
+        StatementsSource $source,
+        Codebase $codebase,
+        NodeTypeProvider $ntp,
+        Aliases $aliases,
+    ): void {
+        $names = self::resolveThrownClassNames($throw->expr, $ntp, $aliases);
+
+        if ($names === null) {
+            return; // type unresolved — prefer false negative
+        }
+
+        foreach ($names as $name) {
+            if (self::extendsDomainException($name, $codebase)) {
+                continue;
+            }
+
+            IssueBuffer::maybeAdd(
+                new InvalidValidateException(
+                    sprintf(
+                        '#[Validate] method %s throws %s, which does not extend \\DomainException; '
+                        . 'the framework only catches DomainException, so this throw bypasses validation',
+                        $methodName,
+                        $name,
+                    ),
+                    new CodeLocation($source, $throw),
+                ),
+                $source->getSuppressedIssues(),
+            );
+
+            return; // one report per throw
+        }
+    }
+
+    /** @return list<string>|null FQCNs of possible thrown classes, or null if unknown */
+    private static function resolveThrownClassNames(Node\Expr $expr, NodeTypeProvider $ntp, Aliases $aliases): array|null
+    {
+        if ($expr instanceof Node\Expr\New_ && $expr->class instanceof Node\Name) {
+            $fqcn = AttributeNodeUtil::resolveNameFqcn($expr->class, $aliases);
+
+            return $fqcn !== null ? [$fqcn] : null;
+        }
+
+        $type = $ntp->getType($expr);
+
+        if ($type === null) {
+            return null;
+        }
+
+        $names = [];
+        foreach ($type->getAtomicTypes() as $atomic) {
+            if (! $atomic instanceof TNamedObject) {
+                return null; // mixed / non-object atomic — give up
+            }
+
+            $names[] = ltrim($atomic->value, '\\');
+        }
+
+        return $names;
+    }
+
+    private static function extendsDomainException(string $fqcn, Codebase $codebase): bool
+    {
+        if ($fqcn === self::DOMAIN_EXCEPTION) {
+            return true;
+        }
+
+        if (! $codebase->classOrInterfaceExists($fqcn)) {
+            return false;
+        }
+
+        return $codebase->classExtends($fqcn, self::DOMAIN_EXCEPTION);
+    }
+}

--- a/src/Psalm/Internal/AttributeNodeUtil.php
+++ b/src/Psalm/Internal/AttributeNodeUtil.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Psalm\Internal;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use Psalm\Aliases;
+
+use function ltrim;
+use function strpos;
+use function strtolower;
+use function substr;
+
+/** @internal */
+final class AttributeNodeUtil
+{
+    /**
+     * Resolve the FQCN of any Name node using either the resolvedName attribute (set
+     * when Psalm has run NameResolver) or the file's use-aliases as a fallback
+     */
+    public static function resolveNameFqcn(Name $name, Aliases|null $aliases = null): string|null
+    {
+        $resolved = $name->getAttribute('resolvedName');
+
+        if ($resolved instanceof Name) {
+            return ltrim($resolved->toString(), '\\');
+        }
+
+        if ($name instanceof FullyQualified) {
+            return ltrim($name->toString(), '\\');
+        }
+
+        if ($aliases === null) {
+            return null;
+        }
+
+        $first = $name->getFirst();
+        $rest = '';
+        $full = $name->toString();
+        $sep = strpos($full, '\\');
+        if ($sep !== false) {
+            $first = substr($full, 0, $sep);
+            $rest = substr($full, $sep);
+        }
+
+        $key = strtolower($first);
+        if (isset($aliases->uses[$key])) {
+            return ltrim($aliases->uses[$key] . $rest, '\\');
+        }
+
+        if ($aliases->namespace !== null && $aliases->namespace !== '') {
+            return $aliases->namespace . '\\' . $full;
+        }
+
+        return $full;
+    }
+
+    /**
+     * Resolve the FQCN of an attribute node, falling back to use-aliases when the
+     * NameResolver hasn't tagged the node
+     */
+    public static function resolveAttributeFqcn(Attribute $attr, Aliases|null $aliases = null): string|null
+    {
+        return self::resolveNameFqcn($attr->name, $aliases);
+    }
+
+    /**
+     * Check if an attribute group list contains an attribute with the given FQCN
+     *
+     * @param array<AttributeGroup> $attrGroups
+     */
+    public static function hasAttribute(array $attrGroups, string $targetFqcn, Aliases|null $aliases = null): bool
+    {
+        foreach ($attrGroups as $group) {
+            foreach ($group->attrs as $attr) {
+                if (self::resolveAttributeFqcn($attr, $aliases) === $targetFqcn) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Find the constructor ClassMethod of a Class_ AST node, or null if absent
+     */
+    public static function findConstructor(Node\Stmt\Class_ $class): Node\Stmt\ClassMethod|null
+    {
+        foreach ($class->stmts as $stmt) {
+            if ($stmt instanceof Node\Stmt\ClassMethod && $stmt->name->toLowerString() === '__construct') {
+                return $stmt;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Psalm/Internal/ThrowCollectorVisitor.php
+++ b/src/Psalm/Internal/ThrowCollectorVisitor.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Psalm\Internal;
+
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+
+/**
+ * AST visitor that collects throw expressions from a function-like body
+ *
+ * Stops at nested function-likes (closures, arrow functions, nested functions,
+ * methods, anonymous classes) so that throws inside them are reported by their
+ * own analysis pass rather than the enclosing #[Validate] method.
+ *
+ * @internal
+ */
+final class ThrowCollectorVisitor extends NodeVisitorAbstract
+{
+    /** @var list<Node\Expr\Throw_> */
+    public array $throws = [];
+
+    public function enterNode(Node $node): int|null
+    {
+        if (
+            $node instanceof Node\Expr\Closure
+            || $node instanceof Node\Expr\ArrowFunction
+            || $node instanceof Node\Stmt\Function_
+            || $node instanceof Node\Stmt\ClassMethod
+            || $node instanceof Node\Stmt\Class_
+        ) {
+            return NodeTraverser::DONT_TRAVERSE_CHILDREN;
+        }
+
+        if ($node instanceof Node\Expr\Throw_) {
+            $this->throws[] = $node;
+        }
+
+        return null;
+    }
+}

--- a/src/Psalm/Issue/ConflictingBeingParameterAttribute.php
+++ b/src/Psalm/Issue/ConflictingBeingParameterAttribute.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Psalm\Issue;
+
+use Psalm\Issue\CodeIssue;
+
+/**
+ * Reported when a Being class constructor parameter has both #[Input] and #[Inject]
+ *
+ * The runtime rejects this ambiguity via
+ * {@see \Be\Framework\Exception\ConflictingParameterAttributes}.
+ */
+final class ConflictingBeingParameterAttribute extends CodeIssue
+{
+    public const int ERROR_LEVEL = 1;
+
+    public const int SHORTCODE = 9003;
+}

--- a/src/Psalm/Issue/InvalidValidateException.php
+++ b/src/Psalm/Issue/InvalidValidateException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Psalm\Issue;
+
+use Psalm\Issue\CodeIssue;
+
+/**
+ * Reported when a #[Validate] method throws an exception that does not extend DomainException
+ *
+ * The framework's {@see \Be\Framework\SemanticVariable\SemanticValidator} only
+ * catches DomainException; any other exception propagates as an uncaught error,
+ * which silently bypasses validation.
+ */
+final class InvalidValidateException extends CodeIssue
+{
+    public const int ERROR_LEVEL = 1;
+
+    public const int SHORTCODE = 9002;
+}

--- a/src/Psalm/Issue/MissingBeingParameterAttribute.php
+++ b/src/Psalm/Issue/MissingBeingParameterAttribute.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Psalm\Issue;
+
+use Psalm\Issue\CodeIssue;
+
+/**
+ * Reported when a Being class constructor parameter lacks both #[Input] and #[Inject]
+ *
+ * A "Being class" is identified heuristically by having at least one constructor
+ * parameter annotated with #[Ray\InputQuery\Attribute\Input]. Once identified,
+ * every other constructor parameter must also have either #[Input] or #[Inject];
+ * otherwise the framework throws {@see \Be\Framework\Exception\MissingParameterAttribute}
+ * at runtime.
+ */
+final class MissingBeingParameterAttribute extends CodeIssue
+{
+    public const int ERROR_LEVEL = 1;
+
+    public const int SHORTCODE = 9001;
+}

--- a/src/Psalm/Plugin.php
+++ b/src/Psalm/Plugin.php
@@ -13,12 +13,15 @@ use SimpleXMLElement;
 /**
  * Psalm plugin entry point for Be Framework
  *
- * Registers static-analysis counterparts for two runtime errors:
+ * Registers static-analysis counterparts for three runtime errors:
  *
  * 1. {@see \Be\Framework\Psalm\Issue\MissingBeingParameterAttribute}
  *    Detects Being constructor parameters missing both #[Input] and #[Inject].
  *
- * 2. {@see \Be\Framework\Psalm\Issue\InvalidValidateException}
+ * 2. {@see \Be\Framework\Psalm\Issue\ConflictingBeingParameterAttribute}
+ *    Detects Being constructor parameters with both #[Input] and #[Inject].
+ *
+ * 3. {@see \Be\Framework\Psalm\Issue\InvalidValidateException}
  *    Detects #[Validate] methods that throw exceptions not extending DomainException.
  */
 final class Plugin implements PluginEntryPointInterface
@@ -30,6 +33,7 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Internal/AttributeNodeUtil.php';
         require_once __DIR__ . '/Internal/ThrowCollectorVisitor.php';
         require_once __DIR__ . '/Issue/MissingBeingParameterAttribute.php';
+        require_once __DIR__ . '/Issue/ConflictingBeingParameterAttribute.php';
         require_once __DIR__ . '/Issue/InvalidValidateException.php';
         require_once __DIR__ . '/Handler/BeingParameterAttributeHandler.php';
         require_once __DIR__ . '/Handler/ValidateThrowHandler.php';

--- a/src/Psalm/Plugin.php
+++ b/src/Psalm/Plugin.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Psalm;
+
+use Be\Framework\Psalm\Handler\BeingParameterAttributeHandler;
+use Be\Framework\Psalm\Handler\ValidateThrowHandler;
+use Psalm\Plugin\PluginEntryPointInterface;
+use Psalm\Plugin\RegistrationInterface;
+use SimpleXMLElement;
+
+/**
+ * Psalm plugin entry point for Be Framework
+ *
+ * Registers static-analysis counterparts for two runtime errors:
+ *
+ * 1. {@see \Be\Framework\Psalm\Issue\MissingBeingParameterAttribute}
+ *    Detects Being constructor parameters missing both #[Input] and #[Inject].
+ *
+ * 2. {@see \Be\Framework\Psalm\Issue\InvalidValidateException}
+ *    Detects #[Validate] methods that throw exceptions not extending DomainException.
+ */
+final class Plugin implements PluginEntryPointInterface
+{
+    public function __invoke(RegistrationInterface $registration, SimpleXMLElement|null $config = null): void
+    {
+        // Psalm checks class_exists($handler, false) without autoload, so handler
+        // files must be loaded explicitly before registerHooksFromClass().
+        require_once __DIR__ . '/Internal/AttributeNodeUtil.php';
+        require_once __DIR__ . '/Internal/ThrowCollectorVisitor.php';
+        require_once __DIR__ . '/Issue/MissingBeingParameterAttribute.php';
+        require_once __DIR__ . '/Issue/InvalidValidateException.php';
+        require_once __DIR__ . '/Handler/BeingParameterAttributeHandler.php';
+        require_once __DIR__ . '/Handler/ValidateThrowHandler.php';
+
+        $registration->registerHooksFromClass(BeingParameterAttributeHandler::class);
+        $registration->registerHooksFromClass(ValidateThrowHandler::class);
+    }
+}

--- a/tests/Psalm/Fixture/Invalid/BadBeingConflictingAttributes.php
+++ b/tests/Psalm/Fixture/Invalid/BadBeingConflictingAttributes.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Tests\Psalm\Fixture\Invalid;
+
+use Ray\Di\Di\Inject;
+use Ray\InputQuery\Attribute\Input;
+
+interface ConflictingStorageInterface
+{
+}
+
+final readonly class BadBeingConflictingAttributes
+{
+    public function __construct(
+        #[Input]
+        public string $recordedAt,
+        #[Input]
+        #[Inject]
+        public ConflictingStorageInterface $storage,
+    ) {
+    }
+}

--- a/tests/Psalm/Fixture/Invalid/BadBeingMissingInputAndInject.php
+++ b/tests/Psalm/Fixture/Invalid/BadBeingMissingInputAndInject.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Tests\Psalm\Fixture\Invalid;
+
+use Ray\InputQuery\Attribute\Input;
+
+interface WeightStorageInterface
+{
+}
+
+final readonly class BadBeingMissingInputAndInject
+{
+    public function __construct(
+        #[Input]
+        public string $recordedAt,
+        // Bug: missing #[Input] / #[Inject] — runtime crash.
+        public WeightStorageInterface $storage,
+    ) {
+    }
+}

--- a/tests/Psalm/Fixture/Invalid/BadBeingPartialCoverage.php
+++ b/tests/Psalm/Fixture/Invalid/BadBeingPartialCoverage.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Tests\Psalm\Fixture\Invalid;
+
+use Ray\Di\Di\Inject;
+use Ray\InputQuery\Attribute\Input;
+
+interface ClockInterface
+{
+}
+
+final readonly class BadBeingPartialCoverage
+{
+    public function __construct(
+        #[Input]
+        public string $name,
+        #[Inject]
+        public ClockInterface $clock,
+        // Bug: this one is missing both attributes.
+        public int $age,
+    ) {
+    }
+}

--- a/tests/Psalm/Fixture/Invalid/BadValidatorConditionalThrow.php
+++ b/tests/Psalm/Fixture/Invalid/BadValidatorConditionalThrow.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Tests\Psalm\Fixture\Invalid;
+
+use Be\Framework\Attribute\Validate;
+use DomainException;
+use LogicException;
+
+final class BadValidatorConditionalThrow
+{
+    #[Validate]
+    public function validate(int $score): void
+    {
+        if ($score < 0) {
+            throw new DomainException('negative score'); // OK
+        }
+
+        if ($score > 1000) {
+            // Bug: LogicException is not DomainException.
+            throw new LogicException('score too large');
+        }
+    }
+}

--- a/tests/Psalm/Fixture/Invalid/BadValidatorRuntimeException.php
+++ b/tests/Psalm/Fixture/Invalid/BadValidatorRuntimeException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Tests\Psalm\Fixture\Invalid;
+
+use Be\Framework\Attribute\Validate;
+use RuntimeException;
+
+final class InvalidWeightException extends RuntimeException
+{
+}
+
+final class BadValidatorRuntimeException
+{
+    #[Validate]
+    public function validate(float $weightKg): void
+    {
+        if ($weightKg < 0) {
+            // Bug: extends RuntimeException, not DomainException — silently propagates.
+            throw new InvalidWeightException("Negative weight: {$weightKg}");
+        }
+    }
+}

--- a/tests/Psalm/Fixture/Invalid/BadValidatorThrowsVariable.php
+++ b/tests/Psalm/Fixture/Invalid/BadValidatorThrowsVariable.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Tests\Psalm\Fixture\Invalid;
+
+use Be\Framework\Attribute\Validate;
+use RuntimeException;
+
+final class BadValidatorThrowsVariable
+{
+    #[Validate]
+    public function validate(string $value): void
+    {
+        if ($value === '') {
+            // Bug: variable holds RuntimeException, not DomainException.
+            $error = new RuntimeException('empty value');
+
+            throw $error;
+        }
+    }
+}

--- a/tests/Psalm/Fixture/Valid/GoodBeing.php
+++ b/tests/Psalm/Fixture/Valid/GoodBeing.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Tests\Psalm\Fixture\Valid;
+
+use Ray\Di\Di\Inject;
+use Ray\InputQuery\Attribute\Input;
+
+interface StorageInterface
+{
+}
+
+final readonly class GoodBeing
+{
+    public function __construct(
+        #[Input]
+        public string $recordedAt,
+        #[Inject]
+        public StorageInterface $storage,
+    ) {
+    }
+}

--- a/tests/Psalm/Fixture/Valid/GoodValidator.php
+++ b/tests/Psalm/Fixture/Valid/GoodValidator.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Tests\Psalm\Fixture\Valid;
+
+use Be\Framework\Attribute\Validate;
+use DomainException;
+
+use function filter_var;
+use function strlen;
+
+use const FILTER_VALIDATE_EMAIL;
+
+final class GoodValidator
+{
+    #[Validate]
+    public function validateEmail(string $email): void
+    {
+        if (! filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new DomainException("Invalid email format: {$email}");
+        }
+    }
+
+    #[Validate]
+    public function validateLength(string $name): void
+    {
+        if (strlen($name) === 0) {
+            throw new InvalidNameException('Name must not be empty');
+        }
+    }
+}
+
+final class InvalidNameException extends DomainException
+{
+}

--- a/tests/Psalm/Fixture/Valid/SuppressedBeing.php
+++ b/tests/Psalm/Fixture/Valid/SuppressedBeing.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Tests\Psalm\Fixture\Valid;
+
+use Ray\InputQuery\Attribute\Input;
+
+interface SuppressedStorageInterface
+{
+}
+
+/** @psalm-suppress MissingBeingParameterAttribute */
+final readonly class SuppressedBeing
+{
+    public function __construct(
+        #[Input]
+        public string $recordedAt,
+        public SuppressedStorageInterface $storage,
+    ) {
+    }
+}

--- a/tests/Psalm/Fixture/psalm.xml
+++ b/tests/Psalm/Fixture/psalm.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    phpVersion="8.3"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="." />
+        <ignoreFiles>
+            <directory name="../../../vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <plugins>
+        <pluginClass class="Be\Framework\Psalm\Plugin" />
+    </plugins>
+
+    <issueHandlers>
+        <!-- Suppress unrelated issues so the plugin issues stand alone. -->
+        <UnusedClass errorLevel="suppress" />
+        <UnusedMethod errorLevel="suppress" />
+        <PossiblyUnusedMethod errorLevel="suppress" />
+        <PossiblyUnusedProperty errorLevel="suppress" />
+        <UnusedParam errorLevel="suppress" />
+        <UnusedVariable errorLevel="suppress" />
+        <MissingConstructor errorLevel="suppress" />
+        <PropertyNotSetInConstructor errorLevel="suppress" />
+        <UndefinedAttributeClass errorLevel="suppress" />
+        <UndefinedClass errorLevel="suppress" />
+    </issueHandlers>
+</psalm>

--- a/tests/Psalm/PluginIntegrationTest.php
+++ b/tests/Psalm/PluginIntegrationTest.php
@@ -50,6 +50,15 @@ final class PluginIntegrationTest extends TestCase
         );
     }
 
+    #[TestDox('ConflictingBeingParameterAttribute is reported when #[Input] and #[Inject] are both present')]
+    public function testConflictingInputAndInjectIsReported(): void
+    {
+        $this->assertIssue(
+            'ConflictingBeingParameterAttribute',
+            'BadBeingConflictingAttributes.php',
+        );
+    }
+
     #[TestDox('InvalidValidateException is reported on RuntimeException-based throws')]
     public function testValidatorThrowingRuntimeExceptionIsReported(): void
     {
@@ -84,7 +93,11 @@ final class PluginIntegrationTest extends TestCase
         $invalid = array_values(array_filter($issues, static fn (array $i): bool => str_contains((string) ($i['file_name'] ?? ''), 'Valid/')
                 && in_array(
                     (string) ($i['type'] ?? ''),
-                    ['MissingBeingParameterAttribute', 'InvalidValidateException'],
+                    [
+                        'MissingBeingParameterAttribute',
+                        'ConflictingBeingParameterAttribute',
+                        'InvalidValidateException',
+                    ],
                     true,
                 )));
         $this->assertSame([], $invalid, 'Valid fixtures should not produce plugin issues');

--- a/tests/Psalm/PluginIntegrationTest.php
+++ b/tests/Psalm/PluginIntegrationTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Tests\Psalm;
+
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+
+use function array_filter;
+use function array_values;
+use function dirname;
+use function escapeshellarg;
+use function file_exists;
+use function in_array;
+use function is_array;
+use function json_decode;
+use function shell_exec;
+use function sprintf;
+use function str_contains;
+use function str_ends_with;
+
+/**
+ * Black-box integration test for the Psalm plugin
+ *
+ * Runs the actual `vendor/bin/psalm` binary against `tests/Psalm/Fixture/psalm.xml`
+ * with the plugin enabled, parses the JSON output, and asserts that the expected
+ * issues are reported on the expected files (and that valid fixtures stay clean).
+ */
+final class PluginIntegrationTest extends TestCase
+{
+    /** @var list<array<string, mixed>>|null */
+    private static array|null $cachedIssues = null;
+
+    #[TestDox('MissingBeingParameterAttribute is reported when no #[Input]/#[Inject] is present')]
+    public function testMissingInputAndInjectIsReported(): void
+    {
+        $this->assertIssue(
+            'MissingBeingParameterAttribute',
+            'BadBeingMissingInputAndInject.php',
+        );
+    }
+
+    #[TestDox('MissingBeingParameterAttribute is reported on partially covered Being constructors')]
+    public function testPartialCoverageIsReported(): void
+    {
+        $this->assertIssue(
+            'MissingBeingParameterAttribute',
+            'BadBeingPartialCoverage.php',
+        );
+    }
+
+    #[TestDox('InvalidValidateException is reported on RuntimeException-based throws')]
+    public function testValidatorThrowingRuntimeExceptionIsReported(): void
+    {
+        $this->assertIssue(
+            'InvalidValidateException',
+            'BadValidatorRuntimeException.php',
+        );
+    }
+
+    #[TestDox('InvalidValidateException is reported on conditional non-DomainException throws')]
+    public function testConditionalNonDomainExceptionIsReported(): void
+    {
+        $this->assertIssue(
+            'InvalidValidateException',
+            'BadValidatorConditionalThrow.php',
+        );
+    }
+
+    #[TestDox('InvalidValidateException is reported on variable throws of non-DomainException types')]
+    public function testThrowsVariableIsReported(): void
+    {
+        $this->assertIssue(
+            'InvalidValidateException',
+            'BadValidatorThrowsVariable.php',
+        );
+    }
+
+    #[TestDox('Valid Being and Validator fixtures produce no plugin issues')]
+    public function testValidFixturesProduceNoIssues(): void
+    {
+        $issues = self::issues();
+        $invalid = array_values(array_filter($issues, static fn (array $i): bool => str_contains((string) ($i['file_name'] ?? ''), 'Valid/')
+                && in_array(
+                    (string) ($i['type'] ?? ''),
+                    ['MissingBeingParameterAttribute', 'InvalidValidateException'],
+                    true,
+                )));
+        $this->assertSame([], $invalid, 'Valid fixtures should not produce plugin issues');
+    }
+
+    private function assertIssue(string $type, string $fileSuffix): void
+    {
+        foreach (self::issues() as $issue) {
+            if (
+                ($issue['type'] ?? null) === $type
+                && str_ends_with((string) ($issue['file_name'] ?? ''), $fileSuffix)
+            ) {
+                $this->addToAssertionCount(1);
+
+                return;
+            }
+        }
+
+        $this->fail(sprintf('Expected %s on %s but did not find it in psalm output', $type, $fileSuffix));
+    }
+
+    /** @return list<array<string, mixed>> */
+    private static function issues(): array
+    {
+        if (self::$cachedIssues !== null) {
+            return self::$cachedIssues;
+        }
+
+        $root = dirname(__DIR__, 2);
+        $psalmBin = $root . '/vendor/bin/psalm';
+        $config = __DIR__ . '/Fixture/psalm.xml';
+
+        if (! file_exists($psalmBin)) {
+            self::markTestSkippedWithReason('vendor/bin/psalm not found; run composer install');
+        }
+
+        if (! file_exists($config)) {
+            self::markTestSkippedWithReason('fixture psalm.xml missing: ' . $config);
+        }
+
+        $cmd = sprintf(
+            '%s --config=%s --output-format=json --no-cache --no-progress 2>/dev/null',
+            escapeshellarg($psalmBin),
+            escapeshellarg($config),
+        );
+
+        $stdout = shell_exec($cmd);
+        $stdout = $stdout === null || $stdout === false ? '[]' : $stdout;
+
+        $decoded = json_decode($stdout, true);
+        if (! is_array($decoded)) {
+            $decoded = [];
+        }
+
+        /** @var list<array<string, mixed>> $decoded */
+        self::$cachedIssues = $decoded;
+
+        return $decoded;
+    }
+
+    private static function markTestSkippedWithReason(string $reason): never
+    {
+        self::markTestSkipped($reason);
+    }
+}

--- a/tests/Psalm/PluginIntegrationTest.php
+++ b/tests/Psalm/PluginIntegrationTest.php
@@ -19,6 +19,7 @@ use function shell_exec;
 use function sprintf;
 use function str_contains;
 use function str_ends_with;
+use function str_replace;
 
 /**
  * Black-box integration test for the Psalm plugin
@@ -90,7 +91,10 @@ final class PluginIntegrationTest extends TestCase
     public function testValidFixturesProduceNoIssues(): void
     {
         $issues = self::issues();
-        $invalid = array_values(array_filter($issues, static fn (array $i): bool => str_contains((string) ($i['file_name'] ?? ''), 'Valid/')
+        $invalid = array_values(array_filter($issues, static function (array $i): bool {
+            $fileName = str_replace('\\', '/', (string) ($i['file_name'] ?? ''));
+
+            return str_contains($fileName, 'Valid/')
                 && in_array(
                     (string) ($i['type'] ?? ''),
                     [
@@ -99,7 +103,8 @@ final class PluginIntegrationTest extends TestCase
                         'InvalidValidateException',
                     ],
                     true,
-                )));
+                );
+        }));
         $this->assertSame([], $invalid, 'Valid fixtures should not produce plugin issues');
     }
 
@@ -149,7 +154,7 @@ final class PluginIntegrationTest extends TestCase
 
         $decoded = json_decode($stdout, true);
         if (! is_array($decoded)) {
-            $decoded = [];
+            self::fail('Failed to parse Psalm JSON output: ' . $stdout);
         }
 
         /** @var list<array<string, mixed>> $decoded */

--- a/tests/Psalm/Unit/AttributeNodeUtilTest.php
+++ b/tests/Psalm/Unit/AttributeNodeUtilTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Tests\Psalm\Unit;
+
+use Be\Framework\Psalm\Internal\AttributeNodeUtil;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\ParserFactory;
+use PhpParser\PhpVersion;
+use PHPUnit\Framework\TestCase;
+use Psalm\Aliases;
+
+final class AttributeNodeUtilTest extends TestCase
+{
+    public function testHasAttributeResolvesViaUseAlias(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace App;
+        use Ray\InputQuery\Attribute\Input;
+        final class Foo {
+            public function __construct(#[Input] public string $name) {}
+        }
+        PHP;
+
+        $class = $this->parseFirstClass($code);
+        $aliases = new Aliases('App', uses: ['input' => 'Ray\\InputQuery\\Attribute\\Input']);
+
+        $ctor = AttributeNodeUtil::findConstructor($class);
+        self::assertNotNull($ctor);
+
+        self::assertTrue(
+            AttributeNodeUtil::hasAttribute($ctor->params[0]->attrGroups, 'Ray\\InputQuery\\Attribute\\Input', $aliases),
+        );
+
+        self::assertFalse(
+            AttributeNodeUtil::hasAttribute($ctor->params[0]->attrGroups, 'Ray\\Di\\Di\\Inject', $aliases),
+        );
+    }
+
+    public function testHasAttributeResolvesAliasedImport(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace App;
+        use Ray\InputQuery\Attribute\Input as In;
+        final class Foo {
+            public function __construct(#[In] public string $name) {}
+        }
+        PHP;
+
+        $class = $this->parseFirstClass($code);
+        $aliases = new Aliases('App', uses: ['in' => 'Ray\\InputQuery\\Attribute\\Input']);
+
+        $ctor = AttributeNodeUtil::findConstructor($class);
+        self::assertNotNull($ctor);
+
+        self::assertTrue(
+            AttributeNodeUtil::hasAttribute($ctor->params[0]->attrGroups, 'Ray\\InputQuery\\Attribute\\Input', $aliases),
+        );
+    }
+
+    public function testHasAttributeWithFullyQualifiedNameWithoutAliases(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace App;
+        final class Foo {
+            public function __construct(#[\Ray\InputQuery\Attribute\Input] public string $name) {}
+        }
+        PHP;
+
+        $class = $this->parseFirstClass($code);
+        $aliases = new Aliases('App');
+
+        $ctor = AttributeNodeUtil::findConstructor($class);
+        self::assertNotNull($ctor);
+
+        self::assertTrue(
+            AttributeNodeUtil::hasAttribute($ctor->params[0]->attrGroups, 'Ray\\InputQuery\\Attribute\\Input', $aliases),
+        );
+    }
+
+    public function testFindConstructorReturnsNullWhenAbsent(): void
+    {
+        $code = <<<'PHP'
+        <?php
+        namespace App;
+        final class Foo { public function bar(): void {} }
+        PHP;
+
+        $class = $this->parseFirstClass($code);
+
+        self::assertNull(AttributeNodeUtil::findConstructor($class));
+    }
+
+    private function parseFirstClass(string $code): Class_
+    {
+        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromComponents(8, 3));
+        $ast = $parser->parse($code);
+        self::assertNotNull($ast);
+
+        foreach ($ast as $stmt) {
+            if ($stmt instanceof Namespace_) {
+                foreach ($stmt->stmts as $sub) {
+                    if ($sub instanceof Class_) {
+                        return $sub;
+                    }
+                }
+            }
+
+            if ($stmt instanceof Class_) {
+                return $stmt;
+            }
+        }
+
+        self::fail('No class found in parsed AST');
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a Psalm plugin under `src/Psalm/` (namespace `Be\Framework\Psalm\`) that detects two runtime errors at static-analysis time
- **Rule 1 — `MissingBeingParameterAttribute`**: Being constructor parameters lacking both `#[Input]` and `#[Inject]`. Mirrors the `BecomingArguments` runtime throw. Heuristic: a class is treated as a Being when its constructor has at least one `#[Input]` parameter
- **Rule 2 — `InvalidValidateException`**: `#[Validate]` methods throwing exceptions not extending `\DomainException`. `SemanticValidator` only catches `DomainException`, so other types silently bypass validation. Resolves throw expressions via Psalm's `NodeTypeProvider`, covering `throw new X`, `throw $var`, and ternary/match unions. Skips when the type is unresolved (false-positive avoidance)
- Self-applied: the plugin is registered in the project's own `psalm.xml`, with `src/Psalm/` excluded from analysis to avoid meta-circularity

Closes #60

## Design Notes

- **Why Psalm not PHPStan**: needs `NodeTypeProvider` for variable throws and per-class AST visiting with full alias resolution. Both rules also need access to the original `PhpParser` AST, which Psalm exposes via `AfterClassLikeVisitInterface` / `AfterFunctionLikeAnalysisInterface`
- **Alias resolution**: Psalm does not pre-populate `resolvedName` on attribute names at the visit-time hook, so `AttributeNodeUtil` falls back to `Psalm\Aliases->uses` lookup and namespace-prefix resolution
- **Plugin loading quirk**: Psalm uses `class_exists($handler, false)` (no autoload) when registering hooks, so `Plugin::__invoke` `require_once`-loads handler/issue/internal files before calling `registerHooksFromClass()`
- **`ThrowCollectorVisitor`** stops descent into nested closures, arrow functions, and inner classes via `DONT_TRAVERSE_CHILDREN` — those are visited separately by their own hooks

## Test Plan

- [x] `composer test` — 251 passed
- [x] `composer cs` / `composer psalm` / `composer phpstan` / `composer phpmd` — all clean
- [x] Plugin integration: black-box `vendor/bin/psalm --output-format=json` against `tests/Psalm/Fixture/psalm.xml` with 7 fixtures (2 valid, 5 invalid). Asserts on `type` and `file_name` in the JSON output
- [x] Plugin unit tests: `AttributeNodeUtilTest` covers use-import, aliased import, fully-qualified name, and no-constructor cases
- [x] Self-analysis: `composer psalm` passes with the plugin enabled (and `src/Psalm` ignored to avoid recursion)

## Files

```
src/Psalm/
  Plugin.php                                       # entry point
  Handler/BeingParameterAttributeHandler.php       # Rule 1
  Handler/ValidateThrowHandler.php                 # Rule 2
  Internal/AttributeNodeUtil.php                   # FQN/alias helpers
  Internal/ThrowCollectorVisitor.php               # PhpParser visitor
  Issue/MissingBeingParameterAttribute.php
  Issue/InvalidValidateException.php

tests/Psalm/
  PluginIntegrationTest.php                        # black-box via shell_exec
  Unit/AttributeNodeUtilTest.php                   # FQN resolution unit
  Fixture/psalm.xml                                # standalone config
  Fixture/Valid/{GoodBeing,GoodValidator}.php
  Fixture/Invalid/BadBeing{MissingInputAndInject,PartialCoverage}.php
  Fixture/Invalid/BadValidator{RuntimeException,ConditionalThrow,ThrowsVariable}.php
```

## Known Limitations

- The Being heuristic (`#[Input]` ⇒ Being class) is documented in the handler class docblock. A future opt-in stricter mode could require `#[Be]` to be the actual target. Tracked as future work; the current behaviour matches the scope agreed on in #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Psalm static-analysis plugin to flag constructor parameter attribute issues (missing or conflicting annotations) and to verify that validation methods only throw allowed exception types.
  * Introduced new issue types to surface those problems in analysis results.

* **Tests**
  * Added integration and unit tests with valid/invalid fixtures covering attribute presence, conflicts, and validator throw checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/be-framework/Be.Framework/pull/73)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->