### PR TITLE
Redact #[\SensitiveParameter] values in semantic log payloads

### DIFF
--- a/src/SemanticLog/Logger.php
+++ b/src/SemanticLog/Logger.php
@@ -23,6 +23,7 @@ use Override;
 use Ray\Di\Di\Inject;
 use Ray\InputQuery\Attribute\Input;
 use ReflectionClass;
+use SensitiveParameter;
 use Throwable;
 
 use function array_key_exists;
@@ -274,8 +275,10 @@ final class Logger implements LoggerInterface
                     continue;
                 }
 
+                $isSensitive = $param->getAttributes(SensitiveParameter::class) !== [];
+
                 // For scalar/other types, show the type information
-                $stringValue = match (true) {
+                $stringValue = $isSensitive ? ObjectPropertyExtractor::REDACTED : match (true) {
                     is_string($value) => $value,
                     is_numeric($value) => (string) $value,
                     is_bool($value) => $value ? 'true' : 'false',

--- a/src/SemanticLog/ObjectPropertyExtractor.php
+++ b/src/SemanticLog/ObjectPropertyExtractor.php
@@ -25,6 +25,17 @@ use function is_string;
  * - Non-storable values like resources (excluded)
  * - Constructor parameters marked with PHP's `#[\SensitiveParameter]`:
  *   the matching public property value is replaced with `self::REDACTED`.
+ *
+ * Redaction contract: a property is redacted when the object's constructor
+ * declares a parameter of the *same name* carrying `#[\SensitiveParameter]`.
+ * This matches Be Framework's idiomatic pattern (promoted `public readonly`
+ * properties that mirror constructor parameter names). Implications:
+ * - Classes with no constructor (e.g. `stdClass`) cannot opt in; dynamic
+ *   properties on such classes are never redacted.
+ * - A `public` property whose name does not match any constructor parameter
+ *   is never redacted, even if the class has other sensitive parameters.
+ * - Redaction is shallow: a nested object value is stored as-is and its
+ *   own sensitive sub-properties are not recursively masked.
  */
 final class ObjectPropertyExtractor
 {

--- a/src/SemanticLog/ObjectPropertyExtractor.php
+++ b/src/SemanticLog/ObjectPropertyExtractor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Be\Framework\SemanticLog;
 
 use ReflectionClass;
+use SensitiveParameter;
 
 use function array_walk;
 use function get_object_vars;
@@ -22,9 +23,17 @@ use function is_string;
  * - Uninitialized properties (returns null)
  * - Been instances (excluded from output)
  * - Non-storable values like resources (excluded)
+ * - Constructor parameters marked with PHP's `#[\SensitiveParameter]`:
+ *   the matching public property value is replaced with `self::REDACTED`.
  */
 final class ObjectPropertyExtractor
 {
+    /**
+     * Placeholder written into the log payload in place of a value whose
+     * corresponding constructor parameter is marked `#[\SensitiveParameter]`.
+     */
+    public const string REDACTED = '[REDACTED]';
+
     /**
      * Extract all public properties from an object for logging
      *
@@ -33,37 +42,48 @@ final class ObjectPropertyExtractor
      * @return ObjectProperties Key-value pairs of property names and their values.
      *                          Uninitialized properties are returned as null.
      *                          Been instances and non-JSON-serializable values are excluded.
+     *                          Values for properties whose matching constructor
+     *                          parameter carries `#[\SensitiveParameter]` are
+     *                          replaced with `self::REDACTED`.
      * @phpstan-return array<string, mixed>
      */
     public function extract(object $result): array
     {
-        $properties = $this->collectVisibleProperties($result);
-        $this->mergeDeclaredProperties($properties, $result);
+        $sensitive = self::collectSensitiveParameterNames($result);
+        $properties = $this->collectVisibleProperties($result, $sensitive);
+        $this->mergeDeclaredProperties($properties, $result, $sensitive);
 
         return $properties;
     }
 
-    /** @return array<string, mixed> */
-    private function collectVisibleProperties(object $result): array
+    /**
+     * @param array<string, true> $sensitive
+     *
+     * @return array<string, mixed>
+     */
+    private function collectVisibleProperties(object $result, array $sensitive): array
     {
         $properties = [];
         $dynamicProperties = get_object_vars($result);
         array_walk(
             $dynamicProperties,
-            static function (mixed $value, string $name) use (&$properties): void {
+            static function (mixed $value, string $name) use (&$properties, $sensitive): void {
                 if ($value instanceof Been || ! self::isStorableValue($value)) {
                     return;
                 }
 
-                self::storeProperty($properties, $name, $value);
+                self::storeProperty($properties, $name, isset($sensitive[$name]) ? self::REDACTED : $value);
             },
         );
 
         return $properties;
     }
 
-    /** @param array<string, mixed> $properties */
-    private function mergeDeclaredProperties(array &$properties, object $result): void
+    /**
+     * @param array<string, mixed> $properties
+     * @param array<string, true>  $sensitive
+     */
+    private function mergeDeclaredProperties(array &$properties, object $result, array $sensitive): void
     {
         foreach ((new ReflectionClass($result))->getProperties() as $property) {
             if (! $property->isPublic() || $property->isStatic()) {
@@ -89,8 +109,36 @@ final class ObjectPropertyExtractor
                 continue;
             }
 
-            self::storeProperty($properties, $name, $value);
+            self::storeProperty($properties, $name, isset($sensitive[$name]) ? self::REDACTED : $value);
         }
+    }
+
+    /**
+     * Collect parameter names of the object's constructor that carry `#[\SensitiveParameter]`.
+     *
+     * Be Framework's idiomatic pattern is `public readonly` properties that
+     * mirror constructor parameter names, so a sensitive parameter implies the
+     * same-named property carries a secret.
+     *
+     * @return array<string, true>
+     */
+    private static function collectSensitiveParameterNames(object $result): array
+    {
+        $constructor = (new ReflectionClass($result))->getConstructor();
+        if ($constructor === null) {
+            return [];
+        }
+
+        $sensitive = [];
+        foreach ($constructor->getParameters() as $param) {
+            if ($param->getAttributes(SensitiveParameter::class) === []) {
+                continue;
+            }
+
+            $sensitive[$param->getName()] = true;
+        }
+
+        return $sensitive;
     }
 
     /** @psalm-assert-if-true array<array-key, mixed>|bool|float|int|object|string|null $value */

--- a/tests/Fake/SensitiveCredentialInput.php
+++ b/tests/Fake/SensitiveCredentialInput.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework;
+
+use SensitiveParameter;
+
+final class SensitiveCredentialInput
+{
+    public function __construct(
+        public readonly string $username,
+        #[SensitiveParameter]
+        public readonly string $password,
+    ) {
+    }
+}

--- a/tests/Fake/SensitiveInjectTarget.php
+++ b/tests/Fake/SensitiveInjectTarget.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework;
+
+use Ray\Di\Di\Inject;
+use Ray\Di\Di\Named;
+use Ray\InputQuery\Attribute\Input;
+use SensitiveParameter;
+
+final class SensitiveInjectTarget
+{
+    public function __construct(
+        #[Input] public readonly string $username,
+        #[Inject]
+        #[Named('api_token')]
+        #[SensitiveParameter]
+        public readonly string $apiToken,
+    ) {
+    }
+}

--- a/tests/Fake/UninitializedSensitiveInput.php
+++ b/tests/Fake/UninitializedSensitiveInput.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework;
+
+use SensitiveParameter;
+
+/**
+ * Locks in the order: uninitialized properties are reported as null
+ * BEFORE the sensitivity check runs, so a never-assigned sensitive
+ * property does not get the misleading `[REDACTED]` placeholder.
+ */
+final class UninitializedSensitiveInput
+{
+    public string $password;
+
+    public function __construct(
+        public readonly string $username,
+        #[SensitiveParameter]
+        string $password = '',
+    ) {
+        if ($password !== '') {
+            $this->password = $password;
+        }
+    }
+}

--- a/tests/SemanticLog/LoggerTest.php
+++ b/tests/SemanticLog/LoggerTest.php
@@ -10,6 +10,8 @@ use Be\Framework\ClassWithInjectObject;
 use Be\Framework\FakeProcessedData;
 use Be\Framework\NoConstructorClass;
 use Be\Framework\SemanticVariable\NullValidator;
+use Be\Framework\SensitiveCredentialInput;
+use Be\Framework\SensitiveInjectTarget;
 use Be\Framework\TestInputWithDependency;
 use Be\Framework\TestMultipleDestination;
 use Be\Framework\TestSingleDestination;
@@ -341,5 +343,38 @@ final class LoggerTest extends TestCase
         $this->assertArrayHasKey('injectedObject', $result);
         $this->assertSame('stdClass', $result['injectedObject']);
         $this->assertArrayNotHasKey('missingParam', $result);
+    }
+
+    public function testExtractPropertiesRedactsSensitiveParameter(): void
+    {
+        // A public readonly property whose matching constructor parameter is
+        // marked `#[\SensitiveParameter]` must not appear verbatim in the log.
+        $reflection = new ReflectionClass($this->logger);
+        $method = $reflection->getMethod('extractProperties');
+
+        $input = new SensitiveCredentialInput('alice', 'super-secret-pw');
+        $result = $method->invoke($this->logger, $input);
+
+        $this->assertSame('alice', $result['username']);
+        $this->assertSame(ObjectPropertyExtractor::REDACTED, $result['password']);
+    }
+
+    public function testExtractTranscendentSourcesRedactsSensitiveInject(): void
+    {
+        // `#[Inject]` parameters that also carry `#[\SensitiveParameter]` get
+        // their value replaced in the `inject` source map; the type stays.
+        $reflection = new ReflectionClass($this->logger);
+        $method = $reflection->getMethod('extractTranscendentSources');
+
+        $args = [
+            'username' => 'alice',
+            'apiToken' => 'token-abc-123',
+        ];
+
+        $result = $method->invoke($this->logger, $args, SensitiveInjectTarget::class);
+
+        $this->assertArrayHasKey('apiToken', $result);
+        $this->assertSame('string:' . ObjectPropertyExtractor::REDACTED, $result['apiToken']);
+        $this->assertArrayNotHasKey('username', $result, '#[Input] params do not appear in transcendent sources');
     }
 }

--- a/tests/SemanticLog/LoggerTest.php
+++ b/tests/SemanticLog/LoggerTest.php
@@ -15,6 +15,7 @@ use Be\Framework\SensitiveInjectTarget;
 use Be\Framework\TestInputWithDependency;
 use Be\Framework\TestMultipleDestination;
 use Be\Framework\TestSingleDestination;
+use Be\Framework\UninitializedSensitiveInput;
 use Koriym\SemanticLogger\SemanticLogger;
 use LogicException;
 use PHPUnit\Framework\TestCase;
@@ -357,6 +358,22 @@ final class LoggerTest extends TestCase
 
         $this->assertSame('alice', $result['username']);
         $this->assertSame(ObjectPropertyExtractor::REDACTED, $result['password']);
+    }
+
+    public function testExtractPropertiesUninitializedSensitivePropertyStaysNull(): void
+    {
+        // Order contract: the uninitialized-property short-circuit runs before
+        // the sensitivity check, so a never-assigned sensitive property is
+        // surfaced as null rather than the misleading `[REDACTED]` placeholder
+        // (uninitialized leaks nothing; redacting would falsely imply a value).
+        $reflection = new ReflectionClass($this->logger);
+        $method = $reflection->getMethod('extractProperties');
+
+        $input = new UninitializedSensitiveInput('alice');
+        $result = $method->invoke($this->logger, $input);
+
+        $this->assertSame('alice', $result['username']);
+        $this->assertNull($result['password']);
     }
 
     public function testExtractTranscendentSourcesRedactsSensitiveInject(): void


### PR DESCRIPTION
## Summary

Security fix: passive information disclosure in the semantic log stream.

`ObjectPropertyExtractor` and `Logger::extractTranscendentSources()` previously wrote every public property and every scalar `#[Inject]` value verbatim into the log payload — credentials, API tokens, and other secrets passed through `Becoming` would land in log aggregators with no opt-out for application developers.

This PR teaches the logger to honour PHP's built-in `#[\SensitiveParameter]` attribute:

- A public readonly property whose matching constructor parameter carries `#[\SensitiveParameter]` is logged as `[REDACTED]`.
- A scalar `#[Inject]` argument on a `#[\SensitiveParameter]`-marked parameter is logged as `string:[REDACTED]` (the type stays; the value goes).
- Uninitialized sensitive properties remain `null` — uninitialized is not a secret.
- Object-typed inject values are unchanged (the class name is not a secret and is useful in logs).

No new framework attribute is introduced — we reuse the PHP standard so behaviour aligns with stack-trace masking and the learning cost for developers is zero.

```php
final class Credentials
{
    public function __construct(
        public readonly string $username,
        #[\SensitiveParameter] public readonly string $password,
    ) {}
}
// log payload: { "username": "alice", "password": "[REDACTED]" }
```

## Background

This change addresses the one actionable finding from a security review of the framework's source. Other candidate findings (loop guard, exception-message redaction, validator class-name hardening) were reconsidered and dropped as either developer-side concerns or non-issues under the actual threat model.

## Test plan

- [x] `composer test` — 243 tests pass
- [x] `composer sa` — PHPStan + Psalm clean
- [x] `composer cs` — Doctrine CS clean
- [x] New tests cover both the property path (`testExtractPropertiesRedactsSensitiveParameter`) and the inject path (`testExtractTranscendentSourcesRedactsSensitiveInject`)

https://claude.ai/code/session_01GP31giu42WfXKhx4JazNj9

---
_Generated by [Claude Code](https://claude.ai/code/session_01GP31giu42WfXKhx4JazNj9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Constructor parameters marked sensitive are now redacted in logs and diagnostics; marked values show as "[REDACTED]" instead of real values.
* **New Features**
  * Redaction now applies to public properties tied to sensitive constructor params and to injected/transcendent sources.
* **Tests**
  * Added tests and fixtures covering redaction, uninitialized sensitive properties, and sensitive inject handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/be-framework/Be.Framework/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->