### PR TITLE
Distinguish input vs runtime semantic validation failures

### DIFF
--- a/docs/schemas/becoming-close.json
+++ b/docs/schemas/becoming-close.json
@@ -13,7 +13,8 @@
       "not": {
         "anyOf": [
           { "required": ["error"] },
-          { "required": ["message"] }
+          { "required": ["message"] },
+          { "required": ["origin"] }
         ]
       }
     },
@@ -42,6 +43,11 @@
     "message": {
       "type": "string",
       "description": "Exception message when the chain ended in failure."
+    },
+    "origin": {
+      "type": "string",
+      "enum": ["input", "runtime"],
+      "description": "Provenance of a semantic validation failure: 'input' when the first metamorphosis (incoming input) failed validation, 'runtime' when a later metamorphosis failed. Absent for non-semantic failures."
     }
   },
   "additionalProperties": false

--- a/src/Becoming.php
+++ b/src/Becoming.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Be\Framework;
 
+use Be\Framework\Exception\InputSemanticVariableException;
+use Be\Framework\Exception\RuntimeSemanticVariableException;
+use Be\Framework\Exception\SemanticVariableException;
 use Be\Framework\SemanticLog\Logger;
 use Be\Framework\SemanticLog\LoggerInterface;
 use Be\Framework\SemanticVariable\SemanticValidator;
@@ -51,13 +54,24 @@ final class Becoming implements BecomingInterface
     {
         $chainId = $this->logger->openChain($input);
         $current = $input;
+        $isFirst = true;
 
         try {
             // Being reveals its becoming, then becomes it
             while ($nextForm = $this->being->willBe($current)) {
                 $current = $this->being->metamorphose($current, $nextForm);
+                $isFirst = false;
             }
         } catch (Throwable $e) {
+            // Refine semantic validation failures by their position in the chain:
+            // the first metamorphosis validates incoming input (input error),
+            // any later one validates already-validated state (runtime error).
+            if ($e instanceof SemanticVariableException) {
+                $e = $isFirst
+                    ? new InputSemanticVariableException($e->getErrors(), $e)
+                    : new RuntimeSemanticVariableException($e->getErrors(), $e);
+            }
+
             try {
                 $this->logger->closeChain(null, $chainId, $e);
             } catch (Throwable) {

--- a/src/Becoming.php
+++ b/src/Becoming.php
@@ -7,6 +7,7 @@ namespace Be\Framework;
 use Be\Framework\Exception\InputSemanticVariableException;
 use Be\Framework\Exception\RuntimeSemanticVariableException;
 use Be\Framework\Exception\SemanticVariableException;
+use Be\Framework\SemanticLog\Context\BecomingCloseContext;
 use Be\Framework\SemanticLog\Logger;
 use Be\Framework\SemanticLog\LoggerInterface;
 use Be\Framework\SemanticVariable\SemanticValidator;
@@ -66,14 +67,22 @@ final class Becoming implements BecomingInterface
             // Refine semantic validation failures by their position in the chain:
             // the first metamorphosis validates incoming input (input error),
             // any later one validates already-validated state (runtime error).
+            // Callers receive the refined subtype, while the chain-close log keeps
+            // the original error class (consistent with the inner span) and carries
+            // the input/runtime distinction as `origin`.
+            $loggedException = $e;
+            $origin = null;
             if ($e instanceof SemanticVariableException) {
+                $origin = $isFirst
+                    ? BecomingCloseContext::ORIGIN_INPUT
+                    : BecomingCloseContext::ORIGIN_RUNTIME;
                 $e = $isFirst
                     ? new InputSemanticVariableException($e->getErrors(), $e)
                     : new RuntimeSemanticVariableException($e->getErrors(), $e);
             }
 
             try {
-                $this->logger->closeChain(null, $chainId, $e);
+                $this->logger->closeChain(null, $chainId, $loggedException, $origin);
             } catch (Throwable) {
                 // A failure inside error logging must not mask the original
                 // metamorphosis exception. Swallow the logging error and

--- a/src/Exception/InputSemanticVariableException.php
+++ b/src/Exception/InputSemanticVariableException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Exception;
+
+/**
+ * Thrown when semantic validation fails on the first metamorphosis (input error)
+ *
+ * The very first transformation turns the user-supplied input object into its
+ * first form, validating the data that flowed in from the outside. A failure
+ * here means the input itself is invalid - an error attributable to the caller.
+ *
+ * @see RuntimeSemanticVariableException for failures in later transformations
+ */
+final class InputSemanticVariableException extends SemanticVariableException
+{
+}

--- a/src/Exception/RuntimeSemanticVariableException.php
+++ b/src/Exception/RuntimeSemanticVariableException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Exception;
+
+/**
+ * Thrown when semantic validation fails after the first metamorphosis (runtime error)
+ *
+ * Once data has passed input validation, any further metamorphosis works on
+ * already-validated state. A validation failure at this stage signals an
+ * internal inconsistency in the transformation logic rather than bad input -
+ * an error attributable to the program itself.
+ *
+ * @see InputSemanticVariableException for failures in the first transformation
+ */
+final class RuntimeSemanticVariableException extends SemanticVariableException
+{
+}

--- a/src/Exception/SemanticVariableException.php
+++ b/src/Exception/SemanticVariableException.php
@@ -6,6 +6,7 @@ namespace Be\Framework\Exception;
 
 use Be\Framework\SemanticVariable\Errors;
 use DomainException;
+use Throwable;
 
 use function array_map;
 use function count;
@@ -16,11 +17,19 @@ use function implode;
  *
  * Wraps multiple semantic validation errors from the SemanticVariable system.
  * Provides access to all individual validation failures.
+ *
+ * This is the common base type. Depending on where in the metamorphosis chain
+ * validation failed, {@see Becoming} refines it into a more specific subtype:
+ * - {@see InputSemanticVariableException} for the first metamorphosis (input error)
+ * - {@see RuntimeSemanticVariableException} for any later metamorphosis (runtime error)
+ *
+ * Catching this base type still catches both subtypes.
  */
-final class SemanticVariableException extends DomainException
+class SemanticVariableException extends DomainException
 {
     public function __construct(
         private readonly Errors $errors,
+        Throwable|null $previous = null,
     ) {
         $errorMessages = array_map(
             static fn ($exception) => $exception->getMessage(),
@@ -31,7 +40,7 @@ final class SemanticVariableException extends DomainException
             ? $errorMessages[0]
             : 'Multiple semantic validation errors: ' . implode(', ', $errorMessages);
 
-        parent::__construct($message);
+        parent::__construct($message, 0, $previous);
     }
 
     /**

--- a/src/SemanticLog/Context/BecomingCloseContext.php
+++ b/src/SemanticLog/Context/BecomingCloseContext.php
@@ -25,17 +25,25 @@ final class BecomingCloseContext extends AbstractContext implements JsonSerializ
 
     public const string EXIT_ERROR = 'error';
 
+    public const string ORIGIN_INPUT = 'input';
+
+    public const string ORIGIN_RUNTIME = 'runtime';
+
     /**
      * @param string            $exit    Exit status for the chain (self::EXIT_SUCCESS|self::EXIT_ERROR).
      * @param class-string|null $final   FQCN of the terminal being, or null if the chain failed.
      * @param string|null       $error   FQCN of the thrown exception, or null on success.
      * @param string|null       $message Exception message, or null on success.
+     * @param string|null       $origin  Provenance of a semantic validation failure
+     *                                    (self::ORIGIN_INPUT|self::ORIGIN_RUNTIME), or null when
+     *                                    the failure is not a semantic validation error.
      */
     public function __construct(
         public readonly string $exit,
         public readonly string|null $final = null,
         public readonly string|null $error = null,
         public readonly string|null $message = null,
+        public readonly string|null $origin = null,
     ) {
     }
 
@@ -52,6 +60,10 @@ final class BecomingCloseContext extends AbstractContext implements JsonSerializ
         if ($this->error !== null) {
             $payload['error'] = $this->error;
             $payload['message'] = $this->message ?? '';
+
+            if ($this->origin !== null) {
+                $payload['origin'] = $this->origin;
+            }
         }
 
         return $payload;

--- a/src/SemanticLog/Logger.php
+++ b/src/SemanticLog/Logger.php
@@ -81,7 +81,7 @@ final class Logger implements LoggerInterface
      *                        `becoming-close.json`, so we refuse to emit one.
      */
     #[Override]
-    public function closeChain(object|null $final, string $openId, Throwable|null $exception = null): void
+    public function closeChain(object|null $final, string $openId, Throwable|null $exception = null, string|null $origin = null): void
     {
         if ($openId === '') {
             return;
@@ -92,6 +92,7 @@ final class Logger implements LoggerInterface
                 exit: BecomingCloseContext::EXIT_ERROR,
                 error: $exception::class,
                 message: $exception->getMessage(),
+                origin: $origin,
             ), $openId);
 
             return;

--- a/src/SemanticLog/LoggerInterface.php
+++ b/src/SemanticLog/LoggerInterface.php
@@ -37,8 +37,10 @@ interface LoggerInterface
      * @param object|null    $final     Terminal being reached on success; null if the chain failed
      * @param string         $openId    Open ID from the corresponding openChain call
      * @param Throwable|null $exception Exception that ended the chain, or null on success
+     * @param string|null    $origin    Provenance of a semantic validation failure ('input'|'runtime'),
+     *                                  or null when the failure is not a semantic validation error
      */
-    public function closeChain(object|null $final, string $openId, Throwable|null $exception = null): void;
+    public function closeChain(object|null $final, string $openId, Throwable|null $exception = null, string|null $origin = null): void;
 
     /**
      * Log transformation start

--- a/tests/BecomingTest.php
+++ b/tests/BecomingTest.php
@@ -13,6 +13,7 @@ use Be\Framework\Exception\MissingParameterAttribute;
 use Be\Framework\Exception\RuntimeSemanticVariableException;
 use Be\Framework\Exception\SemanticVariableException;
 use Be\Framework\Exception\UnbecomingException;
+use Be\Framework\SemanticLog\Context\BecomingCloseContext;
 use Be\Framework\SemanticLog\Logger;
 use Be\Framework\SemanticVariable\Errors;
 use Be\Framework\SemanticVariable\SemanticValidator;
@@ -249,17 +250,14 @@ final class BecomingTest extends TestCase
         }
     }
 
-    public function testChainCloseLogRecordsRefinedSubtype(): void
+    public function testChainCloseLogRecordsBaseErrorAndInputOrigin(): void
     {
-        // The chain-close log must record the refined subtype FQCN, which fixes the
-        // "refine BEFORE closeChain" ordering in Becoming::__invoke. Use a real
+        // The chain-close log records the ORIGINAL base exception class (consistent
+        // with the inner being_error_close span) and carries the input/runtime
+        // distinction via `origin` — not by swapping the class name. Use a real
         // SemanticLogger so the emitted becoming_close payload can be inspected.
-        $injector = new Injector(new BecomingTestModule());
-        $semanticValidator = new SemanticValidator('MyVendor\\MyApp\\SemanticVariables');
-        $becomingArguments = new BecomingArguments($injector, $semanticValidator);
         $semanticLogger = new SemanticLogger();
-        $logger = new Logger($semanticLogger, $becomingArguments);
-        $becoming = new Becoming($injector, 'MyVendor\\MyApp', $logger, $becomingArguments);
+        $becoming = $this->becomingWithLogger($semanticLogger);
 
         try {
             $becoming(new BecomingTestSemanticInvalid('invalid-email'));
@@ -268,14 +266,50 @@ final class BecomingTest extends TestCase
             // expected
         }
 
+        $context = $this->becomingCloseContext($semanticLogger);
+        $this->assertSame('error', $context['exit']);
+        $this->assertSame(SemanticVariableException::class, $context['error']);
+        $this->assertSame(BecomingCloseContext::ORIGIN_INPUT, $context['origin']);
+    }
+
+    public function testChainCloseLogRecordsRuntimeOrigin(): void
+    {
+        // A validation failure on a later metamorphosis is logged with origin=runtime.
+        $semanticLogger = new SemanticLogger();
+        $becoming = $this->becomingWithLogger($semanticLogger);
+
+        try {
+            $becoming(new BecomingTestRuntimeStart('seed'));
+            $this->fail('Expected RuntimeSemanticVariableException');
+        } catch (RuntimeSemanticVariableException) {
+            // expected
+        }
+
+        $context = $this->becomingCloseContext($semanticLogger);
+        $this->assertSame('error', $context['exit']);
+        $this->assertSame(SemanticVariableException::class, $context['error']);
+        $this->assertSame(BecomingCloseContext::ORIGIN_RUNTIME, $context['origin']);
+    }
+
+    private function becomingWithLogger(SemanticLogger $semanticLogger): Becoming
+    {
+        $injector = new Injector(new BecomingTestModule());
+        $semanticValidator = new SemanticValidator('MyVendor\\MyApp\\SemanticVariables');
+        $becomingArguments = new BecomingArguments($injector, $semanticValidator);
+        $logger = new Logger($semanticLogger, $becomingArguments);
+
+        return new Becoming($injector, 'MyVendor\\MyApp', $logger, $becomingArguments);
+    }
+
+    /** @return array<string, mixed> */
+    private function becomingCloseContext(SemanticLogger $semanticLogger): array
+    {
         $logData = $semanticLogger->toArray();
         assert(is_array($logData['open']) && is_array($logData['open'][0]) && is_array($logData['open'][0]['close']));
         $closeData = $logData['open'][0]['close'];
-        assert(is_array($closeData) && is_array($closeData['context']));
+        assert(is_array($closeData) && $closeData['type'] === 'becoming_close' && is_array($closeData['context']));
 
-        $this->assertSame('becoming_close', $closeData['type']);
-        $this->assertSame('error', $closeData['context']['exit']);
-        $this->assertSame(InputSemanticVariableException::class, $closeData['context']['error']);
+        return $closeData['context'];
     }
 
     public function testTypeMatchingFailureWithFallback(): void

--- a/tests/BecomingTest.php
+++ b/tests/BecomingTest.php
@@ -8,7 +8,9 @@ use Be\Framework\Attribute\Be;
 use Be\Framework\Attribute\Validate;
 use Be\Framework\Exception\BeMatchException;
 use Be\Framework\Exception\ConflictingParameterAttributes;
+use Be\Framework\Exception\InputSemanticVariableException;
 use Be\Framework\Exception\MissingParameterAttribute;
+use Be\Framework\Exception\RuntimeSemanticVariableException;
 use Be\Framework\Exception\SemanticVariableException;
 use Be\Framework\Exception\UnbecomingException;
 use Be\Framework\SemanticVariable\Errors;
@@ -181,6 +183,37 @@ final class BecomingTest extends TestCase
 
         $input = new BecomingTestSemanticInvalid('invalid-email');
         ($this->becoming)($input);
+    }
+
+    public function testFirstMetamorphosisFailsWithInputException(): void
+    {
+        // Validation failing on the first metamorphosis is an input error
+        $input = new BecomingTestSemanticInvalid('invalid-email');
+
+        try {
+            ($this->becoming)($input);
+            $this->fail('Expected InputSemanticVariableException');
+        } catch (InputSemanticVariableException $e) {
+            // The refined input subtype is still a SemanticVariableException
+            $this->assertInstanceOf(SemanticVariableException::class, $e);
+            $this->assertTrue($e->getErrors()->hasErrors());
+        }
+    }
+
+    public function testLaterMetamorphosisFailsWithRuntimeException(): void
+    {
+        // The first transformation succeeds; the second fails validation,
+        // which is a runtime error rather than an input error.
+        $input = new BecomingTestRuntimeStart('seed');
+
+        try {
+            ($this->becoming)($input);
+            $this->fail('Expected RuntimeSemanticVariableException');
+        } catch (RuntimeSemanticVariableException $e) {
+            $this->assertInstanceOf(SemanticVariableException::class, $e);
+            $this->assertNotInstanceOf(InputSemanticVariableException::class, $e);
+            $this->assertTrue($e->getErrors()->hasErrors());
+        }
     }
 
     public function testTypeMatchingFailureWithFallback(): void
@@ -610,6 +643,41 @@ final class BecomingTestSemanticTarget
         #[Input]
         #[Validate('Email')]
         public readonly string $email,  // This will trigger semantic validation for email
+    ) {
+    }
+}
+
+// Runtime semantic validation test fixtures: a two-step chain where the first
+// transformation passes validation and the second produces invalid data.
+#[Be(BecomingTestRuntimeMiddle::class)]
+final class BecomingTestRuntimeStart
+{
+    public function __construct(
+        public readonly string $value,  // no Value semantic class - first step passes
+    ) {
+    }
+}
+
+#[Be(BecomingTestRuntimeFailingTarget::class)]
+final class BecomingTestRuntimeMiddle
+{
+    public readonly string $email;
+
+    public function __construct(
+        #[Input]
+        string $value, // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
+    ) {
+        // Produce an invalid email for the next metamorphosis to validate
+        $this->email = 'invalid-email';
+    }
+}
+
+final class BecomingTestRuntimeFailingTarget
+{
+    public function __construct(
+        #[Input]
+        #[Validate('Email')]
+        public readonly string $email,  // fails semantic validation on the second step
     ) {
     }
 }

--- a/tests/BecomingTest.php
+++ b/tests/BecomingTest.php
@@ -13,9 +13,11 @@ use Be\Framework\Exception\MissingParameterAttribute;
 use Be\Framework\Exception\RuntimeSemanticVariableException;
 use Be\Framework\Exception\SemanticVariableException;
 use Be\Framework\Exception\UnbecomingException;
+use Be\Framework\SemanticLog\Logger;
 use Be\Framework\SemanticVariable\Errors;
 use Be\Framework\SemanticVariable\SemanticValidator;
 use InvalidArgumentException;
+use Koriym\SemanticLogger\SemanticLogger;
 use PHPUnit\Framework\TestCase;
 use Ray\Di\AbstractModule;
 use Ray\Di\Di\Inject;
@@ -24,7 +26,9 @@ use Ray\Di\Injector;
 use Ray\InputQuery\Attribute\Input;
 use RuntimeException;
 
+use function assert;
 use function filter_var;
+use function is_array;
 
 use const FILTER_VALIDATE_EMAIL;
 
@@ -197,6 +201,14 @@ final class BecomingTest extends TestCase
             // The refined input subtype is still a SemanticVariableException
             $this->assertInstanceOf(SemanticVariableException::class, $e);
             $this->assertTrue($e->getErrors()->hasErrors());
+
+            // The original base exception is preserved as the cause so the real
+            // validation site stays reachable. Pin it on the Becoming rewrap path
+            // (not just in the direct-construction unit tests).
+            $previous = $e->getPrevious();
+            $this->assertInstanceOf(SemanticVariableException::class, $previous);
+            $this->assertNotInstanceOf(InputSemanticVariableException::class, $previous);
+            $this->assertSame($e->getErrors(), $previous->getErrors());
         }
     }
 
@@ -213,7 +225,57 @@ final class BecomingTest extends TestCase
             $this->assertInstanceOf(SemanticVariableException::class, $e);
             $this->assertNotInstanceOf(InputSemanticVariableException::class, $e);
             $this->assertTrue($e->getErrors()->hasErrors());
+
+            // Cause chain preserved through the rewrap, same Errors carried over.
+            $previous = $e->getPrevious();
+            $this->assertInstanceOf(SemanticVariableException::class, $previous);
+            $this->assertNotInstanceOf(RuntimeSemanticVariableException::class, $previous);
+            $this->assertSame($e->getErrors(), $previous->getErrors());
         }
+    }
+
+    public function testBranchingFirstStepFailsWithInputException(): void
+    {
+        // The first metamorphosis through the array/branching path (performTypeMatching)
+        // must classify a validation failure as an input error, just like the linear path.
+        $input = new BecomingTestSemanticFailureInput('invalid-email');
+
+        try {
+            ($this->becoming)($input);
+            $this->fail('Expected InputSemanticVariableException');
+        } catch (InputSemanticVariableException $e) {
+            $this->assertNotInstanceOf(RuntimeSemanticVariableException::class, $e);
+            $this->assertTrue($e->getErrors()->hasErrors());
+        }
+    }
+
+    public function testChainCloseLogRecordsRefinedSubtype(): void
+    {
+        // The chain-close log must record the refined subtype FQCN, which fixes the
+        // "refine BEFORE closeChain" ordering in Becoming::__invoke. Use a real
+        // SemanticLogger so the emitted becoming_close payload can be inspected.
+        $injector = new Injector(new BecomingTestModule());
+        $semanticValidator = new SemanticValidator('MyVendor\\MyApp\\SemanticVariables');
+        $becomingArguments = new BecomingArguments($injector, $semanticValidator);
+        $semanticLogger = new SemanticLogger();
+        $logger = new Logger($semanticLogger, $becomingArguments);
+        $becoming = new Becoming($injector, 'MyVendor\\MyApp', $logger, $becomingArguments);
+
+        try {
+            $becoming(new BecomingTestSemanticInvalid('invalid-email'));
+            $this->fail('Expected InputSemanticVariableException');
+        } catch (InputSemanticVariableException) {
+            // expected
+        }
+
+        $logData = $semanticLogger->toArray();
+        assert(is_array($logData['open']) && is_array($logData['open'][0]) && is_array($logData['open'][0]['close']));
+        $closeData = $logData['open'][0]['close'];
+        assert(is_array($closeData) && is_array($closeData['context']));
+
+        $this->assertSame('becoming_close', $closeData['type']);
+        $this->assertSame('error', $closeData['context']['exit']);
+        $this->assertSame(InputSemanticVariableException::class, $closeData['context']['error']);
     }
 
     public function testTypeMatchingFailureWithFallback(): void

--- a/tests/BecomingTest.php
+++ b/tests/BecomingTest.php
@@ -307,7 +307,11 @@ final class BecomingTest extends TestCase
         $logData = $semanticLogger->toArray();
         assert(is_array($logData['open']) && is_array($logData['open'][0]) && is_array($logData['open'][0]['close']));
         $closeData = $logData['open'][0]['close'];
-        assert(is_array($closeData) && $closeData['type'] === 'becoming_close' && is_array($closeData['context']));
+        assert(is_array($closeData) && is_array($closeData['context']));
+
+        // A real assertion (not assert()) so the shape check still holds when
+        // zend.assertions is disabled.
+        $this->assertSame('becoming_close', $closeData['type']);
 
         return $closeData['context'];
     }
@@ -761,10 +765,11 @@ final class BecomingTestRuntimeMiddle
 
     public function __construct(
         #[Input]
-        string $value, // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
+        string $value,
     ) {
-        // Produce an invalid email for the next metamorphosis to validate
-        $this->email = 'invalid-email';
+        // Carry the seed forward as the email for the next step. The seed ('seed')
+        // is not a valid email, so the SECOND metamorphosis fails semantic validation.
+        $this->email = $value;
     }
 }
 

--- a/tests/Exception/InputSemanticVariableExceptionTest.php
+++ b/tests/Exception/InputSemanticVariableExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Exception;
+
+use Be\Framework\SemanticVariable\Errors;
+use DomainException;
+use PHPUnit\Framework\TestCase;
+
+final class InputSemanticVariableExceptionTest extends TestCase
+{
+    public function testIsSemanticVariableException(): void
+    {
+        $errors = new Errors([new DomainException('Invalid input')]);
+        $exception = new InputSemanticVariableException($errors);
+
+        $this->assertInstanceOf(SemanticVariableException::class, $exception);
+    }
+
+    public function testGetErrorsAndMessage(): void
+    {
+        $errors = new Errors([new DomainException('Invalid email format')]);
+        $exception = new InputSemanticVariableException($errors);
+
+        $this->assertSame('Invalid email format', $exception->getMessage());
+        $this->assertSame($errors, $exception->getErrors());
+    }
+
+    public function testPreviousIsChained(): void
+    {
+        $errors = new Errors([new DomainException('Invalid input')]);
+        $previous = new SemanticVariableException($errors);
+
+        $exception = new InputSemanticVariableException($errors, $previous);
+
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Exception/RuntimeSemanticVariableExceptionTest.php
+++ b/tests/Exception/RuntimeSemanticVariableExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Be\Framework\Exception;
+
+use Be\Framework\SemanticVariable\Errors;
+use DomainException;
+use PHPUnit\Framework\TestCase;
+
+final class RuntimeSemanticVariableExceptionTest extends TestCase
+{
+    public function testIsSemanticVariableException(): void
+    {
+        $errors = new Errors([new DomainException('Internal inconsistency')]);
+        $exception = new RuntimeSemanticVariableException($errors);
+
+        $this->assertInstanceOf(SemanticVariableException::class, $exception);
+    }
+
+    public function testGetErrorsAndMessage(): void
+    {
+        $errors = new Errors([new DomainException('Invalid email format')]);
+        $exception = new RuntimeSemanticVariableException($errors);
+
+        $this->assertSame('Invalid email format', $exception->getMessage());
+        $this->assertSame($errors, $exception->getErrors());
+    }
+
+    public function testPreviousIsChained(): void
+    {
+        $errors = new Errors([new DomainException('Internal inconsistency')]);
+        $previous = new SemanticVariableException($errors);
+
+        $exception = new RuntimeSemanticVariableException($errors, $previous);
+
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}


### PR DESCRIPTION
## Background

Semantic-variable validation can fail at any point in a metamorphosis chain, but until now every failure raised the same `SemanticVariableException` with no indication of *where* it occurred.

Semantically there are two distinct kinds of failure:

- **Input error**: validation fails on the **first** metamorphosis (input → first form). The data the caller supplied is invalid — an external/caller fault.
- **Runtime error**: data that already passed validation fails on a **later** metamorphosis. This is an internal inconsistency in the transformation logic — a program fault.

An early idea was to distinguish them with HTTP status codes (400/500), but bringing HTTP semantics into the framework felt out of place. Instead, the distinction is carried **by exception subtype**.

## Changes

- `SemanticVariableException` is kept as the common base type (made non-final, gains an optional `?Throwable $previous`). `catch (SemanticVariableException)` still catches both subtypes, preserving backward compatibility.
- Two new final subtypes:
  - `InputSemanticVariableException` — validation failed on the first metamorphosis (input error)
  - `RuntimeSemanticVariableException` — validation failed on a later metamorphosis (runtime error)
- `Becoming::__invoke()` is the only component aware of a transformation's position in the chain, so it classifies the failure there: an `$isFirst` flag selects the subtype on catch, the original exception is preserved as `$previous`, and the refined subtype is thrown to callers.
- Public signatures of `BecomingArguments` / `SemanticValidator` are unchanged.

### Semantic-log consistency (`origin` field)

The classification is also surfaced in the semantic log without introducing a span/chain class-name asymmetry:

- `BecomingCloseContext` gains `ORIGIN_INPUT` / `ORIGIN_RUNTIME` constants and an optional `origin` field (emitted only on semantic-validation error exits).
- `LoggerInterface::closeChain` / `Logger::closeChain` thread the `origin` value through.
- The chain-close log records the **original base exception class** (consistent with the inner `being_error_close` span) and expresses input/runtime as `origin`, rather than swapping the class name.
- `becoming-close.json` documents `origin` (enum `input`/`runtime`, forbidden on the success branch).

## Tests

- `BecomingTest`: first metamorphosis failure → `InputSemanticVariableException`; later metamorphosis failure → `RuntimeSemanticVariableException`. Existing tests that expect the base type still pass.
- Cause-chain hardening on the real `Becoming` rewrap path: asserts `getPrevious()` chaining and `Errors` propagation (not only in direct-construction unit tests).
- Branching first-step classification: a validation failure through `performTypeMatching` is classified as an input error.
- Chain-close logging: a real `SemanticLogger` is injected to assert the emitted `becoming_close` payload records the base error class plus the correct `origin`.
- `InputSemanticVariableExceptionTest` / `RuntimeSemanticVariableExceptionTest`: cover `getErrors()`, message building, base-type relationship, and `$previous` chaining.

## Verified

- `composer test` — 252 passing
- `composer cs-fix` — no violations
- `composer sa` — PHPStan and Psalm both clean
- `composer phpmd` — clean

## Backward compatibility

- Code catching `SemanticVariableException` keeps working, since both subtypes are instances of the base.
- The exception message and `getErrors()` behavior are unchanged.
- `LoggerInterface::closeChain` gains a trailing optional parameter only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPywNci6PvvBNvYYqDA8v8